### PR TITLE
Add support for CI testing of PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,29 @@
+---
+
+name: Run Pull Request CI Verification
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    container:
+      image: registry.suse.com/bci/golang:1.21-openssl
+
+    steps:
+      - name: Checkout PR sources
+        uses: actions/checkout@v4
+        with:
+          path: telemetry-server
+
+      - name: Checkout SUSE/telemetry companion sources
+        uses: actions/checkout@v4
+        with:
+          repository: SUSE/telemetry
+          path: telemetry
+
+      - name: Run tests in verbose mode
+        run: cd telemetry-server && make test-verbose

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.DEFAULT_GOAL := build
+
+SUBDIRS = \
+  server/gorilla
+
+TARGETS = fmt vet build clean test test-verbose
+
+.PHONY: $(TARGETS)
+
+$(TARGETS):
+	$(foreach subdir, $(SUBDIRS), $(MAKE) -C $(subdir) $@)

--- a/Makefile.subdir
+++ b/Makefile.subdir
@@ -1,0 +1,22 @@
+.DEFAULT_GOAL := build
+
+.PHONY: fmt vet build clean test test-verbose
+
+fmt:
+	go fmt ./...
+
+vet:
+	go vet ./...
+
+build: vet
+	go build ./...
+
+clean:
+	go clean
+	go clean -testcache
+
+test: build
+	go clean -testcache && go test -cover ./...
+
+test-verbose: build
+	go clean -testcache && go test -v -cover ./...

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # telemetry-server
-Proof of Concept Telemetry Server scaffolding
+This is the basic implementation of the SUSE Telemetry Gateway service.
 
-To use this code you will need to checkout the 2 telemetry POC related
-repos under the same directory:
+To use this code you will need to checkout both telemetry repositories
+under the same directory:
 
 * github.com/SUSE/telemetry
 * github.com/SUSE/telemetry-server
@@ -28,4 +28,15 @@ configured telemetry item data store, as follows:
     --config ../../testdata/config/localClient.yaml \
     --tag abc=pqr --tag xyz \
     --telemetry=SLE-SERVER-Test ../../examples/telemetry/SLE-SERVER-Test.json
+```
+
+# testing
+
+Ensure that you have checked out both telemetry repositories under the
+same directory and then cd into the telemetry-server repo and run the
+as follows:
+
+```
+% cd telemetry-server
+% make test
 ```

--- a/server/gorilla/Makefile
+++ b/server/gorilla/Makefile
@@ -1,0 +1,1 @@
+include ../../Makefile.subdir


### PR DESCRIPTION
Add support for CI testing of PRs 
    
Add a top-level Makefile that can drive testing and related actions.
    
This top-level Makefile itself implements a simple wrapper for the 
configured target actions that invokes them via a recursive make in
the specified subdirectories.
    
A Makefile.subdir is provided that will run the target actions, and 
should be symlinked into the relevant subdirectories.
    
Update README.md with instructions on how to run tests, and cleanup
some stale text.
    
A GitHub Action CI workflow is defined that will trigger the tests
to be run when a PR is proposed or updated.
    
Caveat: Currently uses local checkouts for testing purposes
    
Closes: #8