### PR TITLE
Simplify Annotation Tags storage in the Telemetry DB

### DIFF
--- a/app/client.go
+++ b/app/client.go
@@ -43,14 +43,9 @@ func (a *App) RegisterClient(ar *AppRequest) {
 
 	client.RegistrationDate = types.Now().String()
 	client.AuthToken = "sometoken"
-	res, err := a.TelemetryDB.Conn.Exec(`INSERT INTO clients(clientInstanceId, RegistrationDate, AuthToken) VALUES(?,?,?)`, client.ClientInstanceId, client.RegistrationDate, client.AuthToken)
+	err = client.Insert(a.TelemetryDB.Conn)
 	if err != nil {
-		ar.ErrorResponse(http.StatusInternalServerError, "failed to insert clients row")
-		return
-	}
-	client.Id, err = res.LastInsertId()
-	if err != nil {
-		ar.ErrorResponse(http.StatusInternalServerError, "failed to retrieve client id for inserted clients row")
+		ar.ErrorResponse(http.StatusInternalServerError, "failed to register new client")
 		return
 	}
 


### PR DESCRIPTION
Representing annotation tags individually in the telemetry DB leads to complex table relationships; additional tables are required to group the tags associated with a specific telemetry data item, which then needs to be referenced by the table representing the telemetry data items.

Switching to a scheme where the sorted set of tags (with duplicates removed) that are associated with a telemetry data item are joined using a separator character that is also prepended and appended to the string, allows us to store these string encoded tag sets in a simple table which can be easily referenced from the telemetry data item table.

It is still reasonably easy to search for tag sets with a matching tag entry, either via SQL queries or programmatically, by pattern matching for the separator chartacter prefixed and/or suffixed to desired tag.

Removed the redundant tagElements and tagLists tables.

Also updated the ClientsRow handling to match that of other tables, and fixed a typo in the structure definition.

Relates: #12