### PR TITLE
Handle compressed payload in the request to /telemetry/report handler

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1,8 +1,11 @@
 package app
 
 import (
+	"compress/gzip"
+	"compress/zlib"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 
@@ -28,6 +31,19 @@ type AppRequest struct {
 	W    http.ResponseWriter
 	R    *http.Request
 	Vars map[string]string
+}
+
+func (ar *AppRequest) getReader() (io.ReadCloser, error) {
+	// Check the Content-Encoding header
+	switch ar.R.Header.Get("Content-Encoding") {
+	case "gzip":
+		return gzip.NewReader(ar.R.Body)
+	case "deflate":
+		return zlib.NewReader(ar.R.Body)
+	default:
+		return ar.R.Body, nil
+	}
+
 }
 
 func (ar *AppRequest) ContentType(contentType string) {

--- a/app/handler_report.go
+++ b/app/handler_report.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"encoding/json"
-
 	"io"
 	"log"
 	"net/http"

--- a/app/handler_report.go
+++ b/app/handler_report.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"encoding/json"
+
 	"io"
 	"log"
 	"net/http"
@@ -13,8 +14,17 @@ import (
 
 func (a *App) ReportTelemetry(ar *AppRequest) {
 	log.Printf("INF: %s %s Processing", ar.R.Method, ar.R.URL)
+
+	reader, err := ar.getReader()
+	if err != nil {
+		ar.ErrorResponse(http.StatusInternalServerError, "Failed to decompress request body")
+		return
+	}
+
+	defer reader.Close()
+
 	// retrieve the request body
-	reqBody, err := io.ReadAll(ar.R.Body)
+	reqBody, err := io.ReadAll(reader)
 	if err != nil {
 		ar.ErrorResponse(http.StatusBadRequest, err.Error())
 		return


### PR DESCRIPTION
This change handles compressed payload in the /telemetry/report handler

Determines whether the request payload is compressed content or not based on the Content-Encoding Header and supports the gzip compression algorithm.

Also adds a unittest to test the compressed payload handling

Addresses: https://github.com/SUSE/telemetry-server/issues/7