### PR TITLE
Add level prefixes to log message generation

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -107,24 +107,24 @@ func (a *App) ListenOn() string {
 func (a *App) Initialize() {
 
 	if err := a.TelemetryDB.Connect(); err != nil {
-		log.Fatalf("failed to initialize DB connection: %s", err.Error())
+		log.Fatalf("ERR: failed to initialize DB connection: %s", err.Error())
 	}
 
 	if err := a.TelemetryDB.EnsureTablesExist(dbTables); err != nil {
-		log.Fatalf("failed to ensure required tables exist: %s", err.Error())
+		log.Fatalf("ERR: failed to ensure required tables exist: %s", err.Error())
 	}
 
 	if err := a.StagingDB.Connect(); err != nil {
-		log.Fatalf("failed to initialize Staging DB connection: %s", err.Error())
+		log.Fatalf("ERR: failed to initialize Staging DB connection: %s", err.Error())
 	}
 
 	if err := a.StagingDB.EnsureTablesExist(dbTablesStaging); err != nil {
-		log.Fatalf("failed to ensure required tables exist: %s", err.Error())
+		log.Fatalf("ERR: failed to ensure required tables exist: %s", err.Error())
 	}
 }
 
 func (a *App) Run() {
-	log.Printf("Starting Telemetry Server App on %s", a.ListenOn())
+	log.Printf("INF: Starting Telemetry Server App on %s", a.ListenOn())
 	log.Fatal(http.ListenAndServe(a.ListenOn(), a.Handler))
 }
 

--- a/app/config.go
+++ b/app/config.go
@@ -58,7 +58,7 @@ func (cfg *Config) Path() string {
 }
 
 func (cfg *Config) Load() error {
-	log.Printf("cfgPath: %q", cfg.cfgPath)
+	log.Printf("DBG: cfgPath: %q", cfg.cfgPath)
 	_, err := os.Stat(cfg.cfgPath)
 	if os.IsNotExist(err) {
 		return fmt.Errorf("config file '%s' doesn't exist: %s", cfg.cfgPath, err)
@@ -69,7 +69,7 @@ func (cfg *Config) Load() error {
 		return fmt.Errorf("failed to read contents of config file '%s': %s", cfg.cfgPath, err)
 	}
 
-	log.Printf("Contents: %q", contents)
+	log.Printf("DBG: Contents: %q", contents)
 	err = yaml.Unmarshal(contents, cfg)
 	if err != nil {
 		return fmt.Errorf("failed to parse contents of config file '%s': %s", cfg.cfgPath, err)

--- a/app/database.go
+++ b/app/database.go
@@ -26,7 +26,7 @@ func (d *DbConnection) Setup(dbcfg DBConfig) {
 func (d *DbConnection) Connect() (err error) {
 	d.Conn, err = sql.Open(d.Driver, d.DataSource)
 	if err != nil {
-		log.Printf("Failed to connect to DB '%s:%s': %s", d.Driver, d.DataSource, err.Error())
+		log.Printf("ERR: failed to connect to DB '%s:%s': %s", d.Driver, d.DataSource, err.Error())
 	}
 
 	return
@@ -35,10 +35,10 @@ func (d *DbConnection) Connect() (err error) {
 func (d *DbConnection) EnsureTablesExist(tables map[string]string) (err error) {
 	for name, columns := range tables {
 		createCmd := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s %s", name, columns)
-		log.Printf("createCmd:\n%s", createCmd)
+		log.Printf("DBG: createCmd:\n%s", createCmd)
 		_, err = d.Conn.Exec(createCmd)
 		if err != nil {
-			log.Printf("failed to create table %q: %s", name, err.Error())
+			log.Printf("ERR: failed to create table %q: %s", name, err.Error())
 			return
 		}
 	}

--- a/app/tables.go
+++ b/app/tables.go
@@ -151,7 +151,7 @@ func (t *TelemetryDataRow) Insert(DB *sql.DB) (err error) {
 		t.ClientId, t.CustomerId, t.TelemetryId, t.TelemetryType, t.Timestamp, t.DataItem,
 	)
 	if err != nil {
-		log.Printf("failed to add telemetryData entry for customerId %q telemetryId %q: %s", t.CustomerId, t.TelemetryId, err.Error())
+		log.Printf("ERR: failed to add telemetryData entry for customerId %q telemetryId %q: %s", t.CustomerId, t.TelemetryId, err.Error())
 		return err
 	}
 	id, err := res.LastInsertId()
@@ -207,7 +207,7 @@ func (r *ReportStagingTableRow) Insert(DB *sql.DB) (err error) {
 		r.Key, r.Data, false, r.ReceivedTimestamp,
 	)
 	if err != nil {
-		log.Printf("failed to insert Report entry with ReportId %q: %s", r.Key, err.Error())
+		log.Printf("ERR: failed to insert Report entry with ReportId %q: %s", r.Key, err.Error())
 		return err
 	}
 
@@ -217,7 +217,7 @@ func (r *ReportStagingTableRow) Insert(DB *sql.DB) (err error) {
 func (r *ReportStagingTableRow) Delete(DB *sql.DB) (err error) {
 	_, err = DB.Exec("DELETE FROM reports WHERE key = ?", r.Key)
 	if err != nil {
-		log.Printf("failed to delete Report entry with ReportId %q: %s", r.Key, err.Error())
+		log.Printf("ERR: failed to delete Report entry with ReportId %q: %s", r.Key, err.Error())
 		return err
 	}
 

--- a/server/gorilla/main.go
+++ b/server/gorilla/main.go
@@ -46,14 +46,14 @@ func main() {
 
 	parseCommandLineFlags()
 
-	log.Printf("Preparing to start gorilla/mux based server with options: %s", opts)
+	log.Printf("INF: Preparing to start gorilla/mux based server with options: %s", opts)
 
 	cfg := app.NewConfig(opts.config)
 	if err := cfg.Load(); err != nil {
 		log.Fatal(err)
 	}
 
-	log.Printf("Config: %v", cfg)
+	log.Printf("INF: Config: %v", cfg)
 
 	a, _ := InitializeApp(cfg)
 


### PR DESCRIPTION
This will make it easier to determine which level to use when switching log/slog.