### PR TITLE
Initial Dockerfile support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+FROM registry.suse.com/bci/golang:1.21-openssl AS builder
+
+RUN set -euo pipefail; zypper -n  in --no-recommends git make ; zypper -n clean;
+
+# Create a temporary workspace
+WORKDIR /var/cache
+
+# For now, we need this since we use replace directive to point to the local telemetry module in go.mod
+RUN git clone https://github.com/SUSE/telemetry
+RUN cd telemetry; make build
+
+# Copy local code to the container image.
+RUN mkdir ./telemetry-server
+COPY . ./telemetry-server
+
+RUN cd telemetry-server; make build
+
+# Final Image: Start a new build stage with bci-base image as the base and copy the build artifacts from the previous stage into this new stage.
+FROM registry.suse.com/bci/bci-base:15.6
+
+RUN set -euo pipefail; zypper -n  in --no-recommends sqlite3 ; zypper -n clean;
+
+COPY --from=builder /var/cache/telemetry-server/server/telemetry-server/telemetry-server /usr/bin/telemetry-server
+COPY --from=builder /var/cache/telemetry-server/testdata/config/localServer.yaml /etc/susetelemetry/server.cfg
+
+#### This block can be removed once we have the package built with a spec that creates user/group/folders
+ARG user=tsvc
+ARG group=tsvc
+ARG uid=1001
+ARG gid=1001
+RUN mkdir -p /var/lib/${user}
+RUN groupadd -g ${gid} ${group}
+RUN useradd -r -g ${group} -u ${uid} -d /var/lib/${user} -s /sbin/nologin -c "user for telemetry-server" ${user}
+RUN chown -R ${user}:${group} /var/lib/${user}
+
+RUN mkdir -p /tmp/telemetry/server /tmp/susetelemetry
+RUN chown -R ${user}:${group} /usr/bin/telemetry-server /tmp/telemetry/server /tmp/susetelemetry
+
+
+# Put additional files into container
+RUN mkdir -p /app
+COPY entrypoint.bash /app
+RUN chmod 700 /app/entrypoint.bash
+
+ENTRYPOINT ["/app/entrypoint.bash"]
+CMD ["--config", "/etc/susetelemetry/server.cfg"]
+

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ under the same directory:
 * github.com/SUSE/telemetry
 * github.com/SUSE/telemetry-server
 
-In one terminal session you can cd to the telemetry-server/server/gorrila
+In one terminal session you can cd to the telemetry-server/server/telemetry-server
 directory and run the server as follows:
 
 ```
@@ -15,6 +15,18 @@ directory and run the server as follows:
 % rm -rf /tmp/telemetry /tmp/susetelemetry
 % mkdir -p /tmp/telemetry/{client,server} /tmp/susetelemetry 
 % go run . --config ../../testdata/config/localServer.yaml
+```
+
+The telemetry-server can be run as a docker container.
+Build the image:
+```
+% cd telemetry-server
+% docker build -t telemetry-server .
+```
+Run the docker container:
+NOTE:  --network=host is used only for local docker run based testing
+```
+% docker run --network=host --rm -it -d -p 9999:9999 --name telemetry-server telemetry-server
 ```
 
 Then in another terminal session you can cd to telemetry/cmd/generator

--- a/entrypoint.bash
+++ b/entrypoint.bash
@@ -1,0 +1,48 @@
+#!/bin/bash -eu
+
+export PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+tuser=tsvc
+name=telemetry-server
+_localstatedir=/var
+_tsvcdir=${_localstatedir}/lib/${tuser}
+_certdir=${_tsvcdir}/certs
+
+[ -d ${_certdir} ] && cp -a ${_certdir}/* /etc/pki/trust/anchors
+
+update-ca-certificates
+
+if [[ ! -d ${_tsvcdir} ]]; then
+    echo "Error: no ${_tsvcdir} directory found; did you bind mount the service account dir to ${_tsvcdir}?"
+    exit 1
+fi
+
+uid_gid=(
+    $(stat -c '%u %g' ${_tsvcdir})
+)
+
+# ensure that the required group exists or add it with matching gid
+# if needed
+getent group ${tuser} >/dev/null || groupadd \
+    -r \
+    -g ${uid_gid[1]} \
+    ${tuser}
+
+# ensure that the required user exists or add it with matching uid
+# if needed
+getent passwd ${tuser} >/dev/null || useradd \
+    -r \
+    -g ${tuser} \
+    -u ${uid_gid[0]} \
+    -d ${_tsvcdir} \
+    -s /sbin/nologin \
+    -c "user for ${name}" ${tuser}
+
+chown -R ${uid_gid[0]}:${uid_gid[1]} ${_tsvcdir}
+
+cmd_args=(
+    /usr/bin/${name}
+    "${@}"
+)
+
+su - ${tuser} --shell /bin/bash -c "${cmd_args[*]}"


### PR DESCRIPTION
Add minimal support for building a simple container telemetry-server image with docker.

In the future, we need to add support for building a container with the openSUSE Build Service.