### PR TITLE
Switch to log/slog structured logging

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -31,6 +31,7 @@ type AppRequest struct {
 	W    http.ResponseWriter
 	R    *http.Request
 	Vars map[string]string
+	Log  *slog.Logger
 }
 
 func (ar *AppRequest) getReader() (io.ReadCloser, error) {
@@ -46,8 +47,13 @@ func (ar *AppRequest) getReader() (io.ReadCloser, error) {
 
 }
 
+func (ar *AppRequest) SetHeader(header, value string) {
+	ar.Log.Debug("Response header", slog.String(header, value))
+	ar.W.Header().Set(header, value)
+}
+
 func (ar *AppRequest) ContentType(contentType string) {
-	ar.W.Header().Set("Content-Type", contentType)
+	ar.SetHeader("Content-Type", contentType)
 }
 
 func (ar *AppRequest) ContentTypeJSON() {
@@ -55,6 +61,7 @@ func (ar *AppRequest) ContentTypeJSON() {
 }
 
 func (ar *AppRequest) Status(statusCode int) {
+	ar.Log.Debug("Response status", slog.Int("code", statusCode))
 	ar.W.WriteHeader(statusCode)
 }
 
@@ -63,11 +70,13 @@ func (ar *AppRequest) StatusInternalServerError() {
 }
 
 func (ar *AppRequest) Write(data []byte) (code int, err error) {
+	ar.Log.Debug("Response write", slog.Int("length", len(data)))
 	code, err = ar.W.Write(data)
 	return
 }
 
 func (ar *AppRequest) ErrorResponse(code int, errorMessage string) {
+	ar.Log.Debug("Setting error response", slog.Int("code", code), slog.String("error", errorMessage))
 	ar.JsonResponse(code, map[string]string{"error": errorMessage})
 }
 
@@ -75,7 +84,7 @@ func (ar *AppRequest) JsonResponse(code int, payload any) {
 	respContent, err := json.Marshal(payload)
 	if err != nil {
 		ar.ErrorResponse(http.StatusInternalServerError, err.Error())
-		log.Printf("ERR: %s %s %d: failed to marshal payload: %q", ar.R.Method, ar.R.URL, code, err.Error())
+		ar.Log.Error("Payload marshal failed", slog.Int("code", code), slog.String("error", err.Error()))
 		return
 	}
 
@@ -83,74 +92,120 @@ func (ar *AppRequest) JsonResponse(code int, payload any) {
 	ar.Status(code)
 	writeCode, err := ar.Write(respContent)
 	if err != nil {
-		log.Printf("ERR: %s %s %d: response write failed (%d, %q)", ar.R.Method, ar.R.URL, code, writeCode, err.Error())
+		ar.Log.Error("Response write failed", slog.Int("code", code), slog.Int("writeCode", writeCode), slog.String("error", err.Error()))
 	} else {
-		log.Printf("INF: %s %s %d", ar.R.Method, ar.R.URL, code)
+		ar.Log.Info("Response", slog.Int("code", code))
 	}
 }
 
 // App is a struct tracking the resources associated with the application
 type App struct {
+	debugMode   bool
 	Config      *Config
 	TelemetryDB DbConnection
 	StagingDB   DbConnection
 	Address     ServerAddress
 	Handler     http.Handler
 	Xformers    TelemetryRowXformMapper
+	LogManager  *LogManager
 }
 
-func NewApp(cfg *Config, handler http.Handler) *App {
+func NewApp(cfg *Config, handler http.Handler, debugMode bool) *App {
 	a := new(App)
 
 	a.Config = cfg
+	a.Handler = handler
+	a.debugMode = debugMode
 
+	// setup logging first so remaining setup logs with config settings
+	if err := a.SetupLogging(); err != nil {
+		panic(err)
+	}
+
+	// setup databases
 	a.TelemetryDB.Setup(cfg.DataBases.Telemetry)
 	a.StagingDB.Setup(cfg.DataBases.Staging)
-	a.Address.Setup(cfg.API)
-	a.Handler = handler
 
+	// setup telemetry transformations
 	a.Xformers = new(TelemetryRowXformMap)
 	a.Xformers.SetDefault(new(DefaultTelemetryDataRow))
 	a.Xformers.Register("SLE-SERVER-SCCHwInfo", new(SccHwInfoTelemetryDataRow))
 
+	// setup address
+	a.Address.Setup(cfg.API)
+
 	return a
+}
+
+func (a *App) SetupLogging() error {
+	logCfg := &a.Config.Logging
+
+	a.LogManager = NewLogManager()
+
+	if err := a.LogManager.Config(&a.Config.Logging); err != nil {
+		slog.Error("Failed to configure logging", slog.Any("config", logCfg), slog.String("error", err.Error()))
+		return err
+	}
+
+	if a.debugMode {
+		slog.Debug("Debug mode enabled - setting log level to debug")
+		a.LogManager.SetLevel("DEBUG")
+	}
+
+	if err := a.LogManager.Setup(); err != nil {
+		slog.Error("Failed to setup logging", slog.Any("config", logCfg), slog.String("error", err.Error()))
+		return err
+	}
+
+	return nil
 }
 
 func (a *App) ListenOn() string {
 	return a.Address.String()
 }
 
-func (a *App) Initialize() {
-
-	// telemetry DB setup
-	if err := a.TelemetryDB.Connect(); err != nil {
-		log.Fatalf("ERR: failed to initialize Telemetry DB connection: %s", err.Error())
-	}
-
-	if err := a.TelemetryDB.EnsureTablesExist(dbTablesTelemetry); err != nil {
-		log.Fatalf("ERR: failed to ensure Telemetry DB required tables exist: %s", err.Error())
-	}
-
-	if err := a.TelemetryDB.EnsureTablesExist(dbTablesXform); err != nil {
-		log.Fatalf("ERR: failed to ensure Telemetry DB transform tables exist: %s", err.Error())
-	}
+func (a *App) Initialize() error {
 
 	// staging DB setup
 	if err := a.StagingDB.Connect(); err != nil {
-		log.Fatalf("ERR: failed to initialize Staging DB connection: %s", err.Error())
+		slog.Error("Staging DB connection setup failed", slog.String("error", err.Error()))
+		return err
 	}
 
 	if err := a.StagingDB.EnsureTablesExist(dbTablesStaging); err != nil {
-		log.Fatalf("ERR: failed to ensure Staging DB required tables exist: %s", err.Error())
+		slog.Error("Staging DB tables setup failed", slog.String("error", err.Error()))
+		return err
+	}
+
+	// telemetry DB setup
+	if err := a.TelemetryDB.Connect(); err != nil {
+		slog.Error("Telemetry DB connection setup failed", slog.String("error", err.Error()))
+		return err
+	}
+
+	if err := a.TelemetryDB.EnsureTablesExist(dbTablesTelemetry); err != nil {
+		slog.Error("Telemetry DB standard tables setup failed", slog.String("error", err.Error()))
+		return err
+	}
+
+	if err := a.TelemetryDB.EnsureTablesExist(dbTablesXform); err != nil {
+		slog.Error("Telemetry DB transform tables exist", slog.String("error", err.Error()))
+		return err
 	}
 
 	// telemetry type specific transform setup
 	if err := a.Xformers.SetupDB(a.TelemetryDB.Conn); err != nil {
-		log.Fatalf("ERR: failed to setup storage transforms: %s", err.Error())
+		slog.Error("Telemetry transformers setup failed", slog.String("error", err.Error()))
+		return err
 	}
+
+	return nil
 }
 
 func (a *App) Run() {
-	log.Printf("INF: Starting Telemetry Server App on %s", a.ListenOn())
-	log.Fatal(http.ListenAndServe(a.ListenOn(), a.Handler))
+	slog.Info("Starting Telemetry Server", slog.String("listenOn", a.ListenOn()))
+	if err := http.ListenAndServe(a.ListenOn(), a.Handler); err != nil {
+		slog.Error("ListenAndServe() failed", slog.Any("error", err.Error()))
+		panic(err)
+	}
 }

--- a/app/logging.go
+++ b/app/logging.go
@@ -1,0 +1,379 @@
+package app
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	LOG_LEVEL_DEFAULT slog.Level = slog.LevelInfo
+	LOG_STYLE_DEFAULT string     = "TEXT"
+	LOG_PATH_DEFAULT  string     = "stderr"
+)
+
+type LogLevels struct {
+	validLevels map[string]slog.Level
+}
+
+func NewLogLevels() (logLevels *LogLevels) {
+	logLevels = &LogLevels{
+		validLevels: make(map[string]slog.Level),
+	}
+
+	// define standard names for log levels
+	for _, level := range []slog.Level{
+		slog.LevelDebug,
+		slog.LevelInfo,
+		slog.LevelWarn,
+		slog.LevelError,
+	} {
+		logLevels.validLevels[level.String()] = level
+	}
+
+	// define alternate names for log levels
+	for name, level := range map[string]slog.Level{
+		"dbg":     slog.LevelDebug,
+		"inf":     slog.LevelInfo,
+		"wrn":     slog.LevelWarn,
+		"warning": slog.LevelWarn,
+		"err":     slog.LevelError,
+	} {
+		logLevels.validLevels[name] = level
+	}
+
+	return
+}
+
+func (l *LogLevels) Levels() (levels []string) {
+	for level := range l.validLevels {
+		levels = append(levels, level)
+	}
+	return levels
+}
+
+func (ls *LogLevels) String() string {
+	return "[" + strings.Join(ls.Levels(), ", ") + "]"
+}
+
+func (l *LogLevels) Canonicalize(levelName string) string {
+	return strings.ToUpper(levelName)
+}
+
+func (l *LogLevels) Valid(levelName string) (valid bool) {
+	_, valid = l.validLevels[l.Canonicalize(levelName)]
+	return
+}
+
+func (l *LogLevels) GetLevel(levelName string) (level slog.Level, valid bool) {
+	level, valid = l.validLevels[l.Canonicalize(levelName)]
+	return
+}
+
+type LogStyles struct {
+	validStyles map[string]bool
+}
+
+func NewLogStyles() (logStyles *LogStyles) {
+	logStyles = &LogStyles{
+		validStyles: make(map[string]bool),
+	}
+
+	for _, style := range []string{
+		"TEXT",
+		"JSON",
+		"SYSLOG",
+	} {
+		logStyles.validStyles[style] = true
+	}
+
+	return
+}
+
+func (ls *LogStyles) Styles() (styles []string) {
+	for style := range ls.validStyles {
+		styles = append(styles, style)
+	}
+	return styles
+}
+
+func (ls *LogStyles) String() string {
+	return "[" + strings.Join(ls.Styles(), ", ") + "]"
+}
+
+func (ls *LogStyles) Canonicalize(styleName string) string {
+	return strings.ToUpper(styleName)
+}
+
+func (ls *LogStyles) Valid(styleName string) (valid bool) {
+	valid = ls.validStyles[ls.Canonicalize(styleName)]
+	return
+}
+
+func (ls *LogStyles) GetStyle(styleName string) (style string, valid bool) {
+	style = ls.Canonicalize(styleName)
+	_, valid = ls.validStyles[style]
+	return
+}
+
+type LogManager struct {
+	levels     *LogLevels
+	styles     *LogStyles
+	logger     *slog.Logger
+	logLevel   *slog.LevelVar
+	logStyle   string
+	logPath    string
+	logFile    *os.File
+	logHandler slog.Handler
+}
+
+func NewLogManager() (lm *LogManager) {
+	lm = new(LogManager)
+
+	// init sub structures
+	lm.levels = NewLogLevels()
+	lm.styles = NewLogStyles()
+	lm.logLevel = new(slog.LevelVar)
+
+	// setup defaults
+	lm.logStyle = LOG_STYLE_DEFAULT
+	lm.logLevel.Set(LOG_LEVEL_DEFAULT)
+	lm.logPath = LOG_PATH_DEFAULT
+
+	return
+}
+
+func (lm *LogManager) Logger() *slog.Logger {
+	return lm.logger
+}
+
+func (lm *LogManager) SetLevel(levelName string) (err error) {
+	// if no level is specified default to info
+	if levelName == "" {
+		levelName = LOG_LEVEL_DEFAULT.String()
+	}
+
+	level, valid := lm.levels.GetLevel(levelName)
+	if !valid {
+		return fmt.Errorf(
+			"invalid log level name '%s', must be one of %s (case insensitive)",
+			levelName,
+			lm.levels,
+		)
+	}
+
+	// set the log level
+	lm.logLevel.Set(level)
+
+	return
+}
+
+func (lm *LogManager) SetStyle(styleName string) (err error) {
+	// if no style is specified default to text
+	if styleName == "" {
+		styleName = LOG_STYLE_DEFAULT
+	}
+
+	style, valid := lm.styles.GetStyle(styleName)
+	if !valid {
+		return fmt.Errorf(
+			"invalid log style name '%s', must be one of %s (case insensitive)",
+			styleName,
+			lm.styles,
+		)
+	}
+
+	lm.logStyle = style
+
+	return
+}
+
+func checkLogPathValid(path string) (err error) {
+	// path must be non-empty
+	if len(path) == 0 {
+		return fmt.Errorf("invalid path '%s': must be non-empty", path)
+	}
+
+	// must be able to generate an absolute path from provided path
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return
+	}
+
+	// parent directory must exist, be accessible, and be a directory
+	parent := filepath.Dir(absPath)
+	dirInfo, err := os.Stat(parent)
+	if err != nil {
+		return
+	}
+	if !dirInfo.IsDir() {
+		return fmt.Errorf("parent '%s' of path '%s' is not a directory", parent, path)
+	}
+
+	// if path exists it must be accessible and not a directory
+	pathInfo, err := os.Stat(absPath)
+	if err != nil {
+		// ok if it doesn't exist
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return
+	}
+	if pathInfo.IsDir() {
+		return fmt.Errorf("path '%s' is a directory", path)
+	}
+
+	return
+}
+
+func (lm *LogManager) SetPath(path string) (err error) {
+	// if no path is specified default to stderr
+	if path == "" {
+		path = LOG_PATH_DEFAULT
+	}
+
+	switch path {
+	case "stdout":
+	case "stderr":
+	default:
+		err = checkLogPathValid(path)
+	}
+
+	if err != nil {
+		lm.logPath = path
+	}
+	return
+}
+
+func (lm *LogManager) OpenLog() (err error) {
+	// close existing log befoe opening a new one
+	if err = lm.CloseLog(); err != nil {
+		return
+	}
+
+	// open the appropriate log target
+	switch lm.logPath {
+	case "stdout":
+		lm.logFile = os.Stdout
+	case "stderr":
+		lm.logFile = os.Stderr
+	default:
+		logFile, err := os.OpenFile(
+			lm.logPath,
+			os.O_CREATE|os.O_APPEND|os.O_WRONLY,
+			0600,
+		)
+		if err != nil {
+			return err
+		}
+		lm.logFile = logFile
+	}
+
+	return
+}
+
+func (lm *LogManager) CloseLog() (err error) {
+	// do nothing if no log file is open
+	if lm.logFile == nil {
+		return
+	}
+
+	switch lm.logPath {
+	case "stdout":
+		// nothing to do
+	case "stderr":
+		// nothing to do
+	default:
+		err = lm.logFile.Close()
+	}
+
+	// release the reference to the log file if no error occurred
+	if err == nil {
+		lm.logFile = nil
+	}
+
+	return
+}
+
+func (lm *LogManager) SetupHandler() (err error) {
+	// handler options
+	opts := &slog.HandlerOptions{Level: lm.logLevel}
+
+	switch lm.logStyle {
+	case "JSON":
+		lm.logHandler = slog.NewJSONHandler(lm.logFile, opts)
+	case "TEXT":
+		lm.logHandler = slog.NewTextHandler(lm.logFile, opts)
+	case "SYSLOG":
+		return fmt.Errorf("support for '%s' style not yet implemented", lm.logStyle)
+	default:
+		return fmt.Errorf("'%s' style not supported", lm.logStyle)
+	}
+	return
+}
+
+func (lm *LogManager) Config(cfg *LogConfig) (err error) {
+	// do nothing if no config is provided
+	if cfg == nil {
+		return
+	}
+
+	if err = lm.SetLevel(cfg.Level); err != nil {
+		return
+	}
+
+	if err = lm.SetStyle(cfg.Style); err != nil {
+		return
+	}
+
+	if err = lm.SetPath(cfg.Location); err != nil {
+		return
+	}
+
+	return
+}
+
+func (lm *LogManager) Setup() (err error) {
+	if err = lm.OpenLog(); err != nil {
+		return
+	}
+
+	if err = lm.SetupHandler(); err != nil {
+		return
+	}
+
+	// create a new logger using the new handler
+	lm.logger = slog.New(lm.logHandler)
+
+	// set our handler as the default slog handler
+	slog.SetDefault(lm.logger)
+
+	slog.Info(
+		"Logging initialised",
+		slog.Any("level", lm.logLevel),
+		slog.String("dest", lm.logPath),
+		slog.String("style", lm.logStyle),
+	)
+
+	return
+}
+
+func (lm *LogManager) ConfigAndSetup(cfg *LogConfig) (err error) {
+	if err = lm.Config(cfg); err != nil {
+		return err
+	}
+
+	return lm.Setup()
+}
+
+func SetupBasicLogging(debug bool) (err error) {
+	lm := NewLogManager()
+	if debug {
+		lm.SetLevel("DEBUG")
+	}
+	return lm.Setup()
+}

--- a/server/telemetry-server/app_test.go
+++ b/server/telemetry-server/app_test.go
@@ -67,8 +67,8 @@ dbs:
 	err = s.config.Load()
 	require.NoError(s.T(), err)
 
-	// Initialize your app and setup a router
-	s.app, s.router = InitializeApp(s.config)
+	// Initialize your app and setup a router with debug mode enabled
+	s.app, s.router = InitializeApp(s.config, true)
 
 }
 

--- a/testdata/config/localServer.yaml
+++ b/testdata/config/localServer.yaml
@@ -8,3 +8,7 @@ dbs:
   staging:
     driver: sqlite3
     params: /tmp/telemetry/server/staging.db
+logging:
+  level: info
+  location: stderr
+  style: text


### PR DESCRIPTION
Using slog allows use to log messages at different log levels, and only those messages whose level is at or above the active log level will be emitted.

Add basic log management capabilities to which can be configured via the new logging section in the config file.

The default settings will log info level messages to stderr using the Text var=value format. Also available is the JSON for object format. The syslog like format is not implemented yet.

The config file settings will supersede the default logger once the config has been loaded and the telemetry server app has been setup.

Added a new --debug option which forces the active log level to debug, overriding whatever is specified in the config.

Updated a number of code paths to uses slog, including the methods of AppRequest, which now sets up a customer logger that includes the request method and URL values in all messages that it emits.

Minor cleanup of report staging data base interactions to use the row id field rather than the reportId field for certain operations.

Outstanding work items for follow on PRs:
* Complete switchover to using slog rather log.
* Move log management capabilities to the SUSE/telemetry repo
* Update SUSE/telemetry library to use slog as well

Relates: #10