### PR TITLE
Use JWT based auth tokens.

### DIFF
--- a/app/authentication.go
+++ b/app/authentication.go
@@ -1,0 +1,194 @@
+package app
+
+import (
+	"encoding/base64"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+type AuthManager struct {
+	config       *AuthConfig
+	secret       []byte
+	duration     time.Duration
+	issuer       string
+	methods      []jwt.SigningMethod
+	validMethods []string
+}
+
+var durationSfxMap = map[string]time.Duration{
+	"s": time.Second,
+	"m": time.Minute,
+	"h": time.Hour,
+	"d": time.Hour * 24,
+	"w": time.Hour * 24 * 7,
+}
+
+func validDurationSuffixes() (sfxs string) {
+	for k := range durationSfxMap {
+		sfxs += k
+	}
+	return
+}
+
+// use 1 week as default time duration
+const DEFAULT_AUTH_TIME_DURATION time.Duration = time.Hour * 24 * 7
+
+// authDuration is a helper function that converts an auth di
+func authDuration(cfgDuration string) (timeDuration time.Duration, err error) {
+	// support s for seconds, m for minutes, h for hours, d for days and
+	// w for weeks, with no suffix meaning seconds
+
+	// strip off surrounding whitespace
+	stripped := strings.TrimSpace(cfgDuration)
+
+	// use the default duration if none specified
+	if stripped == "" {
+		stripped = DEF_AUTH_DURATION
+	}
+
+	sfx := strings.TrimLeft(stripped, " +-0123456789")
+	digits := strings.TrimSpace(strings.TrimSuffix(stripped, sfx))
+
+	slog.Debug("timeDuration", slog.String("cfgDuration", cfgDuration), slog.String("stripped", stripped), slog.String("digits", digits), slog.String("sfx", sfx))
+
+	// convert the digits to an int64
+	durationCount, err := strconv.ParseInt(digits, 0, 64)
+	if err != nil {
+		return
+	}
+
+	// duration must be > 0
+	if durationCount <= 0 {
+		err = fmt.Errorf(
+			"invalid auth.duration value '%s', must be greater than 0",
+			cfgDuration,
+		)
+		return
+	}
+
+	// assume seconds if no suffix specified
+	if sfx == "" {
+		sfx = "s"
+	}
+
+	// determine the suffix multiplier
+	sfxMult, ok := durationSfxMap[sfx]
+	if !ok {
+		err = fmt.Errorf(
+			"invalid auth.duration suffix '%s', must be one of [%s]",
+			sfx,
+			validDurationSuffixes(),
+		)
+		return
+	}
+
+	timeDuration = time.Duration(durationCount) * sfxMult
+
+	return
+}
+
+func NewAuthManager(ac *AuthConfig) (am *AuthManager, err error) {
+	am = new(AuthManager)
+	am.secret, err = base64.StdEncoding.DecodeString(ac.Secret)
+	if err != nil {
+		slog.Error("config auth.secret must be a valid base64 encoded value")
+		return nil, err
+	}
+
+	am.duration, err = authDuration(ac.Duration)
+	if err != nil {
+		slog.Error(
+			"config auth.duration invalid",
+			slog.String("auth.duration", ac.Duration),
+			slog.String("error", err.Error()),
+		)
+		return nil, err
+	}
+
+	if ac.Issuer != "" {
+		am.issuer = ac.Issuer
+	} else {
+		am.issuer = "telemetry-service-gateway"
+	}
+
+	am.methods = []jwt.SigningMethod{
+		// first method is the method used for newly generated tokens,
+		// remaining methods are valid for existing tokens. Add new
+		// preferred methods to start of list
+		jwt.SigningMethodHS512,
+		jwt.SigningMethodHS384,
+		jwt.SigningMethodHS256,
+	}
+
+	// generate list of valid methods
+	for _, m := range am.methods {
+		am.validMethods = append(am.validMethods, m.Alg())
+	}
+
+	am.config = ac
+
+	return
+}
+
+func (am *AuthManager) newExpirationFrom(t time.Time) (exp *jwt.NumericDate) {
+	return jwt.NewNumericDate(t.Add(am.duration))
+}
+
+func (am *AuthManager) newExpiration() (exp *jwt.NumericDate) {
+	return am.newExpirationFrom(time.Now())
+}
+
+func (am *AuthManager) Issuer() string {
+	return am.issuer
+}
+
+func (am *AuthManager) SigningMethod() jwt.SigningMethod {
+	return am.methods[0]
+}
+
+func (am *AuthManager) ValidMethods() []string {
+	return am.validMethods
+}
+
+func (am *AuthManager) Subject(sub any) string {
+	return fmt.Sprintf("%v", sub)
+}
+
+func (am *AuthManager) CreateToken() (tokenString string, err error) {
+	token := jwt.NewWithClaims(
+		am.SigningMethod(),
+		jwt.MapClaims{
+			"exp": am.newExpiration(),
+			"iss": am.Issuer(),
+		},
+	)
+
+	tokenString, err = token.SignedString(am.secret)
+	if err != nil {
+		slog.Error("jwt token signing failed", slog.String("error", err.Error()))
+	}
+
+	return
+}
+
+func (am *AuthManager) VerifyToken(tokenString string) (err error) {
+	_, err = jwt.Parse(
+		tokenString,
+		func(*jwt.Token) (any, error) { return am.secret, nil },
+		jwt.WithValidMethods(am.ValidMethods()),
+		jwt.WithIssuer(am.Issuer()),
+		jwt.WithExpirationRequired(),
+	)
+
+	if err != nil {
+		slog.Error("token parse failed", slog.String("tokenString", tokenString))
+		return
+	}
+
+	return
+}

--- a/app/authentication_test.go
+++ b/app/authentication_test.go
@@ -1,0 +1,104 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type AuthenticationTestSuite struct {
+	suite.Suite
+}
+
+func (t *AuthenticationTestSuite) TestTimeDurations() {
+	tests := []struct {
+		name        string
+		config      string
+		expectValue time.Duration
+		expectFail  bool
+	}{
+		{
+			name:        "Empty duration should use default",
+			config:      "",
+			expectValue: time.Hour * 24 * 7,
+		},
+		{
+			name:        "Blank duration should use default",
+			config:      " ",
+			expectValue: time.Hour * 24 * 7,
+		},
+		{
+			name:        "Valid number, no suffix",
+			config:      "22",
+			expectValue: time.Second * 22,
+		},
+		{
+			name:        "Valid number of seconds",
+			config:      "31s",
+			expectValue: time.Second * 31,
+		},
+		{
+			name:        "Valid number of minutes",
+			config:      "6m",
+			expectValue: time.Minute * 6,
+		},
+		{
+			name:        "Valid number of hours",
+			config:      "99h",
+			expectValue: time.Hour * 99,
+		},
+		{
+			name:        "Valid number of days",
+			config:      "222d",
+			expectValue: time.Hour * 24 * 222,
+		},
+		{
+			name:        "Valid number of weeks",
+			config:      "9w",
+			expectValue: time.Hour * 24 * 7 * 9,
+		},
+		{
+			name:       "Invalid number",
+			config:     "0x1a",
+			expectFail: true,
+		},
+		{
+			name:       "Invalid suffix",
+			config:     "1ms",
+			expectFail: true,
+		},
+		{
+			name:       "Suffix only, no number",
+			config:     "d",
+			expectFail: true,
+		},
+		{
+			name:       "Invalid duration, zero",
+			config:     "0",
+			expectFail: true,
+		},
+		{
+			name:       "Invalid duration, negative",
+			config:     "-1",
+			expectFail: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run("Validating config auth duration parsing"+tt.name, func() {
+
+			duration, err := authDuration(tt.config)
+			if tt.expectFail {
+				assert.Error(t.T(), err, "authDuration(%s) should have failed", tt.config)
+			} else {
+				assert.Equal(t.T(), tt.expectValue, duration, "time.Duration(%s) returned wrong value", tt.config)
+			}
+		})
+	}
+}
+
+func TestAuthenticationTestSuite(t *testing.T) {
+	suite.Run(t, new(AuthenticationTestSuite))
+}

--- a/app/config.go
+++ b/app/config.go
@@ -48,17 +48,35 @@ func (lc *LogConfig) String() string {
 	return string(str)
 }
 
+// default duration, in days of an auth token
+const DEF_AUTH_DURATION string = "1w"
+
+type AuthConfig struct {
+	// should not be printed
+	Secret string `yaml:"secret"`
+	// duration that tokens will be valid for
+	Duration string `yaml:"duration"`
+	// issuer name
+	Issuer string `yaml:"issuer"`
+}
+
+func (ac *AuthConfig) String() string {
+	return fmt.Sprintf("{Secret:%s Duration:%s Issuer:%s}", "********", ac.Duration, ac.Issuer)
+}
+
 type Config struct {
 	cfgPath string
 	API     APIConfig `yaml:"api"`
-	//DataStores config.DBConfig `yaml:"datastores"`
+	// database config settings
 	DataBases struct {
 		Telemetry   DBConfig `yaml:"telemetry"`
 		Operational DBConfig `yaml:"operational"`
 		Staging     DBConfig `yaml:"staging"`
-		//add other databases here
 	} `yaml:"dbs"`
+	// logging config settings
 	Logging LogConfig `yaml:"logging"`
+	// authentication config settings
+	Auth AuthConfig `yaml:"auth"`
 }
 
 func NewConfig(cfgFile string) *Config {

--- a/app/handler_register.go
+++ b/app/handler_register.go
@@ -48,8 +48,12 @@ func (a *App) RegisterClient(ar *AppRequest) {
 		return
 	}
 
+	client.AuthToken, err = a.AuthManager.CreateToken()
+	if err != nil {
+		ar.ErrorResponse(http.StatusInternalServerError, "failed to create authtoken for client")
+	}
+
 	client.RegistrationDate = types.Now().String()
-	client.AuthToken = "sometoken"
 	err = client.Insert()
 	if err != nil {
 		ar.ErrorResponse(http.StatusInternalServerError, "failed to register new client")

--- a/app/handler_report.go
+++ b/app/handler_report.go
@@ -14,12 +14,21 @@ import (
 func (a *App) ReportTelemetry(ar *AppRequest) {
 	ar.Log.Info("Processing")
 
+	token := ar.GetAuthToken()
+	if err := a.AuthManager.VerifyToken(token); err != nil {
+		// TODO: Set WWW-Authenticate header appropriately, per
+		// https://www.rfc-editor.org/rfc/rfc9110.html#name-www-authenticate
+		ar.ErrorResponse(http.StatusUnauthorized, "Missing or Invalid Authorization")
+	}
+	ar.Log.Debug("Authorized", slog.String("token", token))
+
+	// TODO: Report has a valid token. It is from a registered client?
+
 	reader, err := ar.getReader()
 	if err != nil {
 		ar.ErrorResponse(http.StatusInternalServerError, "Failed to decompress request body")
 		return
 	}
-
 	defer reader.Close()
 
 	// retrieve the request body

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ replace github.com/SUSE/telemetry-server => ../telemetry-server/
 require (
 	github.com/SUSE/telemetry v0.0.0-20240613193912-dad2f1cdf2a9
 	github.com/go-playground/validator/v10 v10.22.0
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.22.0 h1:k6HsTZ0sTnROkhS//R0O+55JgM8C4Bx7ia+JlgcnOao=
 github.com/go-playground/validator/v10 v10.22.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/server/telemetry-server/go.mod
+++ b/server/telemetry-server/go.mod
@@ -33,6 +33,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/jackc/pgx/v5 v5.6.0 // indirect

--- a/server/telemetry-server/go.sum
+++ b/server/telemetry-server/go.sum
@@ -11,6 +11,8 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.22.0 h1:k6HsTZ0sTnROkhS//R0O+55JgM8C4Bx7ia+JlgcnOao=
 github.com/go-playground/validator/v10 v10.22.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=

--- a/testdata/config/composeServer.yaml
+++ b/testdata/config/composeServer.yaml
@@ -15,3 +15,6 @@ logging:
   level: info
   location: stderr
   style: text
+auth:
+  secret: VGVzdGluZ1NlY3JldAo=
+  duration: 1w

--- a/testdata/config/dockerServer.yaml
+++ b/testdata/config/dockerServer.yaml
@@ -15,3 +15,6 @@ logging:
   level: info
   location: stderr
   style: text
+auth:
+  secret: VGVzdGluZ1NlY3JldAo=
+  duration: 1w

--- a/testdata/config/localServer.yaml
+++ b/testdata/config/localServer.yaml
@@ -15,3 +15,6 @@ logging:
   level: info
   location: stderr
   style: text
+auth:
+  secret: VGVzdGluZ1NlY3JldAo=
+  duration: 1w


### PR DESCRIPTION
Add support for auth management settings to the server config.

Add an AuthManager to the App which provides methods for creating and validating auth tokens.

Update /register handler to generate the auth token using the new AuthManager.

Update /report handler to check for the Authorization header and fail if the provided auth token is not valid.

Updated app tests to support authentication, and verify that requests without authentication fail.

Add tests to validate the parsing of the duration specified in the server config file.

Relates: #35