### PR TITLE
Add support of /authenticate request

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -63,6 +63,10 @@ func (ar *AppRequest) GetAuthToken() string {
 	return strings.TrimPrefix(ar.GetAuthorization(), "Bearer ")
 }
 
+func (ar *AppRequest) GetClientId() string {
+	return ar.GetHeader("X-Telemetry-Client-Id")
+}
+
 func (ar *AppRequest) SetHeader(header, value string) {
 	ar.Log.Debug("Response header", slog.String(header, value))
 	ar.W.Header().Set(header, value)

--- a/app/handler_register.go
+++ b/app/handler_register.go
@@ -29,7 +29,7 @@ func (a *App) RegisterClient(ar *AppRequest) {
 		ar.ErrorResponse(http.StatusBadRequest, err.Error())
 		return
 	}
-	if crReq.ClientInstanceId == "" {
+	if string(crReq.ClientInstanceId) == "" {
 		ar.ErrorResponse(http.StatusBadRequest, "no ClientInstanceId value provided")
 		return
 	}
@@ -37,13 +37,13 @@ func (a *App) RegisterClient(ar *AppRequest) {
 
 	// register the client
 	client := new(ClientsRow)
-	client.Init(&crReq)
+	client.InitRegistration(&crReq)
 	if err = client.SetupDB(&a.OperationalDB); err != nil {
 		ar.Log.Error("clientsRow.SetupDB() failed", slog.String("error", err.Error()))
-		ar.ErrorResponse(http.StatusInternalServerError, "")
+		ar.ErrorResponse(http.StatusInternalServerError, "failed to access DB")
 		return
 	}
-	if client.Exists() {
+	if client.InstIdExists() {
 		ar.ErrorResponse(http.StatusConflict, "specified clientInstanceId already exists")
 		return
 	}

--- a/app/handler_report.go
+++ b/app/handler_report.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strconv"
 
 	"github.com/SUSE/telemetry/pkg/restapi"
 	"github.com/SUSE/telemetry/pkg/types"
@@ -14,16 +15,55 @@ import (
 func (a *App) ReportTelemetry(ar *AppRequest) {
 	ar.Log.Info("Processing")
 
+	// verify that a valid authtoken has been provided
 	token := ar.GetAuthToken()
 	if err := a.AuthManager.VerifyToken(token); err != nil {
 		// TODO: Set WWW-Authenticate header appropriately, per
 		// https://www.rfc-editor.org/rfc/rfc9110.html#name-www-authenticate
 		ar.ErrorResponse(http.StatusUnauthorized, "Missing or Invalid Authorization")
 	}
-	ar.Log.Debug("Authorized", slog.String("token", token))
 
-	// TODO: Report has a valid token. It is from a registered client?
+	ar.Log.Debug(
+		"Bearer Authorization Valid",
+		slog.String("token", token),
+	)
 
+	// verify that the provided client id is a valid number
+	hdrClientId := ar.GetClientId()
+	clientId, err := strconv.ParseInt(hdrClientId, 0, 64)
+	if err != nil {
+		// TODO: Set WWW-Authenticate header appropriately, per
+		// https://www.rfc-editor.org/rfc/rfc9110.html#name-www-authenticate
+		ar.ErrorResponse(http.StatusUnauthorized, "Invalid Client Id")
+	}
+
+	// verify that the request is from a registered client
+	client := new(ClientsRow)
+	client.InitClientId(clientId)
+	if err = client.SetupDB(&a.OperationalDB); err != nil {
+		ar.Log.Error("clientsRow.SetupDB() failed", slog.String("error", err.Error()))
+		ar.ErrorResponse(http.StatusInternalServerError, "failed to access DB")
+		return
+	}
+	if !client.Exists() {
+		// TODO: Set WWW-Authenticate header appropriately, per
+		// https://www.rfc-editor.org/rfc/rfc9110.html#name-www-authenticate
+		ar.ErrorResponse(http.StatusUnauthorized, "Invalid Client Id")
+	}
+
+	// verify that the provided authtoken matches last authtoken issued to the client
+	if client.AuthToken != token {
+		// TODO: Set WWW-Authenticate header appropriately, per
+		// https://www.rfc-editor.org/rfc/rfc9110.html#name-www-authenticate
+		ar.ErrorResponse(http.StatusUnauthorized, "Invalid Authorization")
+	}
+
+	ar.Log.Debug(
+		"Client Authorizated",
+		slog.Int64("clientId", clientId),
+	)
+
+	// handle payload compression
 	reader, err := ar.getReader()
 	if err != nil {
 		ar.ErrorResponse(http.StatusInternalServerError, "Failed to decompress request body")

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace github.com/SUSE/telemetry => ../telemetry/
 replace github.com/SUSE/telemetry-server => ../telemetry-server/
 
 require (
-	github.com/SUSE/telemetry v0.0.0-20240613193912-dad2f1cdf2a9
+	github.com/SUSE/telemetry v0.0.0-20240722191415-be124bb71e5b
 	github.com/go-playground/validator/v10 v10.22.0
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/jackc/pgx/v5 v5.6.0

--- a/server/telemetry-server/go.mod
+++ b/server/telemetry-server/go.mod
@@ -27,7 +27,7 @@ require (
 )
 
 require (
-	github.com/SUSE/telemetry v0.0.0-20240613193912-dad2f1cdf2a9
+	github.com/SUSE/telemetry v0.0.0-20240722191415-be124bb71e5b
 	github.com/SUSE/telemetry-server v0.0.0-20240614161816-bafbd5826391
 )
 

--- a/server/telemetry-server/main.go
+++ b/server/telemetry-server/main.go
@@ -35,6 +35,10 @@ func newAppRequest(w http.ResponseWriter, r *http.Request) *app.AppRequest {
 	}
 }
 
+func (rw *routerWrapper) authenticateClient(w http.ResponseWriter, r *http.Request) {
+	rw.app.AuthenticateClient(newAppRequest(w, r))
+}
+
 func (rw *routerWrapper) registerClient(w http.ResponseWriter, r *http.Request) {
 	rw.app.RegisterClient(newAppRequest(w, r))
 }
@@ -96,6 +100,7 @@ func parseCommandLineFlags() {
 func SetupRouterWrapper(router *mux.Router, app *app.App) {
 	wrapper := newRouterWrapper(router, app)
 
+	router.HandleFunc("/telemetry/authenticate", wrapper.authenticateClient).Methods("POST")
 	router.HandleFunc("/telemetry/register", wrapper.registerClient).Methods("POST")
 	router.HandleFunc("/telemetry/report", wrapper.reportTelemetry).Methods("POST")
 	router.HandleFunc("/healthz", wrapper.healthCheck).Methods("GET", "HEAD")


### PR DESCRIPTION
Note that this change depends upon corresponding changes being landed in the github.com/SUSE/telemetry repo.

Added a new InstIdExists() helper method to the ClientsRow structure which is equivalent to the old Exists() helper. Updated the Exists() helper to now search for clients table entries with a matching Id value.

Add support for handling /authenticate requests allowing clients to obtain an updated authToken.

The /report handling now also requires that clients provide a new X-Telemetry-Client-Id header specifying their client id, and uses this to retrieve the saved authToken value for that client to check that the client id and token values provided match what is stored in the Operational DB's client table.

The /register handling has been tweaked slightly to align with new shared data types and also to use a different client instance id existence check mechanism.

Added new tests to test the /authenticate request and updated the test suite setup to create a test client entry in the operational DB's clients table as well as updating the relevant tests to pass the appropriate header values.