### PR TITLE
Enhancements to docker and docker compose support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+TELEMETRY_REPO_BRANCH = main
+
 include Makefile.compose
 include Makefile.docker
 include Makefile.generate
@@ -8,7 +10,7 @@ SUBDIRS = \
   app \
   server/telemetry-server
 
-TARGETS = fmt vet build clean test test-verbose
+TARGETS = fmt vet build build-only clean test test-verbose
 
 .PHONY: $(TARGETS)
 

--- a/Makefile.compose
+++ b/Makefile.compose
@@ -1,9 +1,12 @@
 # docker compose actions
+
+PG_DOCKER_VOLUME = docker_pgdata
+
 .PHONY: compose-build compose-start compose-up compose-ps compose-status compose-logs compose-stop compose-down compse-clean
 
 # Start the telemetry-server using docker compose
-compose-build:
-	cd docker && docker compose build
+compose-build: vet
+	cd docker && docker compose build --build-arg telemetryRepoBranch=$(TELEMETRY_REPO_BRANCH)
 
 compose-start compose-up: compose-build
 	cd docker && docker compose up -d
@@ -17,5 +20,8 @@ compose-logs:
 compose-stop compose-down: compose-status
 	cd docker && docker compose down
 
-compose-clean: compose-stop
-	docker volume rm docker_pgdata
+compose-clean: compose-stop docker-clean
+	@if docker volume inspect $(PG_DOCKER_VOLUME) >/dev/null 2>&1; then \
+		echo removing docker volume $(PG_DOCKER_VOLUME); \
+		docker volume rm $(PG_DOCKER_VOLUME); \
+	fi

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -2,8 +2,8 @@
 .PHONY: docker-build docker-start docker-run docker-ps docker-status docker-logs docker-stop
 
 # Start the telemetry-server using docker
-docker-build:
-	docker build -t telemetry-server .
+docker-build: vet
+	docker build -t telemetry-server . --build-arg telemetryRepoBranch=$(TELEMETRY_REPO_BRANCH)
 
 docker-start docker-run: docker-build
 	docker run --rm -it -d -p 9999:9999 --name telemetry-server telemetry-server
@@ -16,3 +16,6 @@ docker-logs:
 
 docker-stop: docker-status
 	docker stop telemetry-server
+
+docker-clean:
+	docker buildx prune -f --filter="until=24h"

--- a/Makefile.subdir
+++ b/Makefile.subdir
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := build
 
-.PHONY: fmt vet build clean test test-verbose
+.PHONY: fmt vet build build-only clean test test-verbose
 
 fmt:
 	go fmt ./...
@@ -8,8 +8,10 @@ fmt:
 vet:
 	go vet ./...
 
-build: vet
+build-only:
 	go build ./...
+
+build: vet build-only
 
 clean:
 	go clean

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace github.com/SUSE/telemetry => ../telemetry/
 replace github.com/SUSE/telemetry-server => ../telemetry-server/
 
 require (
-	github.com/SUSE/telemetry v0.0.0-20240722191415-be124bb71e5b
+	github.com/SUSE/telemetry v0.0.0-20240724131408-7d6373a5dac3
 	github.com/go-playground/validator/v10 v10.22.0
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/jackc/pgx/v5 v5.6.0

--- a/server/telemetry-server/go.mod
+++ b/server/telemetry-server/go.mod
@@ -27,7 +27,7 @@ require (
 )
 
 require (
-	github.com/SUSE/telemetry v0.0.0-20240722191415-be124bb71e5b
+	github.com/SUSE/telemetry v0.0.0-20240724131408-7d6373a5dac3
 	github.com/SUSE/telemetry-server v0.0.0-20240614161816-bafbd5826391
 )
 


### PR DESCRIPTION
Add support for specifying an alternate branch to use when cloning the SUSE/telemetry repo.

Update the Dockerfile to retrieve and store details about the target branch in the SUSE/telemetry repo before cloning it; this ensures that the latest version of the specified branch is cloned, avoiding reuse of stale cached layers from previous docker builds.

Added a docker-clean Makefile action to prune builder layers that are older than 24 hours.

Update compose-clean Makefile action to conditionally remove the postgres data volume, avoiding an unnecessary error. Also have the action trigger the docker-clean rule to recover disk space.