### PR TITLE
Eliminate unnecessary JSON blob processing

### DIFF
--- a/app/telemetry_default.go
+++ b/app/telemetry_default.go
@@ -25,25 +25,12 @@ type DefaultTelemetryDataRow struct {
 	// Embed the common rows
 	TelemetryDataCommon
 
-	DataItem any `json:"dataItem"`
+	DataItem []byte `json:"dataItem"`
 }
 
 func (t *DefaultTelemetryDataRow) Init(dItm *telemetrylib.TelemetryDataItem, bHdr *telemetrylib.TelemetryBundleHeader, tagSetId int64) (err error) {
 	t.TelemetryDataCommon.Init(dItm, bHdr, tagSetId)
-
-	// marshal telemetry data as JSON
-	jsonData, err := json.Marshal(dItm.TelemetryData)
-	if err != nil {
-		slog.Error(
-			"JSON marshal failed",
-			slog.Int64("clientId", t.ClientId),
-			slog.String("telemetryId", t.TelemetryId),
-			slog.String("timestamp", t.Timestamp),
-			slog.String("error", err.Error()),
-		)
-		return
-	}
-	t.DataItem = jsonData
+	t.DataItem = []byte(dItm.TelemetryData)
 
 	return
 }

--- a/server/telemetry-admin/.gitignore
+++ b/server/telemetry-admin/.gitignore
@@ -1,1 +1,1 @@
-telemetry-server
+telemetry-admin

--- a/server/telemetry-server/app_test.go
+++ b/server/telemetry-server/app_test.go
@@ -114,7 +114,7 @@ func (t *AppTestSuite) TestReportTelemetry() {
 	// Simulated request handled via the router's ServeHTTP
 	// Response recorded via the httptest.HttpRecorder
 
-	body := createReportPayload(t.T())
+	body := createReportPayload()
 
 	rr, err := postToReportTelemetryHandler(body, "", true, t)
 	assert.NoError(t.T(), err)
@@ -136,7 +136,7 @@ func (t *AppTestSuite) TestReportTelemetryCompressedPayloadGZIP() {
 	// Simulated request handled via the router's ServeHTTP
 	// Response recorded via the httptest.HttpRecorder
 
-	body := createReportPayload(t.T())
+	body := createReportPayload()
 
 	//Compress payload
 	cbody, err := compressedData([]byte(body), "gzip")
@@ -161,7 +161,7 @@ func (t *AppTestSuite) TestReportTelemetryCompressedPayloadDeflate() {
 	// Simulated request handled via the router's ServeHTTP
 	// Response recorded via the httptest.HttpRecorder
 
-	body := createReportPayload(t.T())
+	body := createReportPayload()
 
 	//Compress payload
 	cbody, err := compressedData([]byte(body), "deflate")
@@ -447,23 +447,19 @@ func TestAppTestSuite(t *testing.T) {
 	suite.Run(t, new(AppTestSuite))
 }
 
-func createReportPayload(t *testing.T) (reportPayload string) {
+func createReportPayload() (reportPayload string) {
 	// Create 2 dataitems
 	telemetryType := types.TelemetryType("SLE-SERVER-Test")
 	itags1 := types.Tags{types.Tag("ikey1=ivalue1"), types.Tag("ikey2")}
 	itags2 := types.Tags{types.Tag("ikey1=ivalue1")}
-	payload := `
-			{
-				"ItemA": 1,
-				"ItemB": "b",
-				"ItemC": "c"
-			}
-			`
+	payload := types.NewTelemetryBlob([]byte(`{
+		"ItemA": 1,
+		"ItemB": "b",
+		"ItemC": "c"
+	}`))
 
-	item1, err := telemetrylib.NewTelemetryDataItem(telemetryType, itags1, []byte(payload))
-	assert.NoError(t, err)
-	item2, err := telemetrylib.NewTelemetryDataItem(telemetryType, itags2, []byte(payload))
-	assert.NoError(t, err)
+	item1 := telemetrylib.NewTelemetryDataItem(telemetryType, itags1, payload)
+	item2 := telemetrylib.NewTelemetryDataItem(telemetryType, itags2, payload)
 
 	client_id := int64(12345)
 


### PR DESCRIPTION
Ensure that provided telemetry data JSOB blob data is not processed unless needed, avoiding unmarshaling and re-marshaling of the field.

Depends up breaking changes in SUSE/telemetry#42

Fixes: #27