### PR TITLE
HTTP 401 responses should include WWW-Authentciate header

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -81,6 +81,25 @@ func (ar *AppRequest) ContentTypeJSON() {
 	ar.ContentType("application/json")
 }
 
+func (ar *AppRequest) SetWwwAuthenticate(challenge, realm, scope string) {
+	ar.SetHeader(
+		"WWW-Authenticate",
+		fmt.Sprintf(`%s realm="%s" scope="%s"`, challenge, realm, scope),
+	)
+}
+
+func (ar *AppRequest) SetWwwAuthScope(scope string) {
+	ar.SetWwwAuthenticate("Bearer", "suse-telemetry-service", scope)
+}
+
+func (ar *AppRequest) SetWwwAuthReauth() {
+	ar.SetWwwAuthScope("authenticate")
+}
+
+func (ar *AppRequest) SetWwwAuthRegister() {
+	ar.SetWwwAuthScope("register")
+}
+
 func (ar *AppRequest) Status(statusCode int) {
 	ar.Log.Debug("Response status", slog.Int("code", statusCode))
 	ar.W.WriteHeader(statusCode)


### PR DESCRIPTION
When generating a HTTP 401 StatusUnauthorized response to a telemetry client the response should include an appropriate WWW-Authenticate header indicating to the client what action it should take to address it's lack of authorization.

The generated WWW-Authenticate header uses a custom "Bearer" challenge specifying a realm of "suse-telemetry-service" with a scope of either "authenticate" or "register" indicating the appropriate action which the client needs to take.

Fixes: #47