### PR TITLE
Add local-server make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ ifeq ($(MAKELEVEL),0)
 
 TELEMETRY_REPO_BRANCH = main
 
+include Makefile.local-server
 include Makefile.compose
 include Makefile.docker
 include Makefile.generate

--- a/Makefile.local-server
+++ b/Makefile.local-server
@@ -1,0 +1,21 @@
+ifdef DEBUG
+TELEMETRY_DEBUG = --debug
+else
+TELEMETRY_DEBUG =
+endif
+TELEMETRY_SERVER = server/telemetry-server
+TELEMETRY_TMP = /tmp/telemetry
+TELEMETRY_SERVER_TMP = $(TELEMETRY_TMP)/server
+
+.PHONY: local-server local-server-cleanup local-server-start
+
+local-server-cleanup:
+	cd $(TELEMETRY_SERVER); \
+	rm -rf $(TELEMETRY_SERVER_TMP)
+
+local-server-start:
+	cd $(TELEMETRY_SERVER); \
+	mkdir -p $(TELEMETRY_SERVER_TMP); \
+	go run . $(TELEMETRY_DEBUG) --config ../../testdata/config/localServer.yaml
+
+local-server: local-server-cleanup local-server-start

--- a/README.md
+++ b/README.md
@@ -26,6 +26,26 @@ directory and run the server as follows:
 % go run . --config ../../testdata/config/localServer.yaml
 ```
 
+Alternatively you can run `make local-server` in the top-level directory to
+launch the local server as shown above. You can optionally specify the DEBUG
+variable to enabled DEBUG level logging, as follows:
+
+```
+% make local-server DEBUG=true
+cd server/telemetry-server; \
+rm -rf /tmp/telemetry/server
+cd server/telemetry-server; \
+mkdir -p /tmp/telemetry/server; \
+go run . --debug --config ../../testdata/config/localServer.yaml
+time=2024-08-12T17:08:11.756-04:00 level=DEBUG msg="Logging initialised" level=DEBUG dest=stderr style=TEXT
+time=2024-08-12T17:08:11.756-04:00 level=DEBUG msg="Preparing to start gorilla/mux based server" options="{\"config\":\"../../testdata/config/localServer.yaml\",\"debug\":true}"
+time=2024-08-12T17:08:11.756-04:00 level=DEBUG msg="Loading config" path=../../testdata/config/localServer.yaml
+...
+```
+
+To stop the local server instance you will need to hit Ctrl-C or otherwise
+kill the server process.
+
 ## Starting the telemetry server with docker compose
 Note that the following instructions expect that you have a modern version
 of docker with the compose plugin installed.

--- a/app/handler_authenticate.go
+++ b/app/handler_authenticate.go
@@ -52,7 +52,7 @@ func (a *App) AuthenticateClient(ar *AppRequest) {
 		return
 	}
 
-	// confirm that the provided clientInstanceId SHA matches the registered on
+	// confirm that the provided clientInstanceId SHA matches the registered one
 	instIdHash := client.ClientInstanceId.Hash(caReq.InstIdHash.Method)
 	if !instIdHash.Match(&caReq.InstIdHash) {
 		ar.Log.Error(


### PR DESCRIPTION
The local-server target can be used to start a local server instance via the `make` command.

Also fixed a typo.