### PR TITLE
Ensure make fails if a submake fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ TARGETS = fmt vet build build-only clean test test-clean test-verbose tidy
 .PHONY: $(TARGETS)
 
 $(TARGETS):
-	$(foreach subdir, $(SUBDIRS), $(MAKE) -C $(subdir) $@;)
+	$(foreach subdir, $(SUBDIRS), $(MAKE) -C $(subdir) $@ || exit 1;)
 else
 include Makefile.golang
 endif

--- a/Makefile.compose
+++ b/Makefile.compose
@@ -15,7 +15,7 @@ compose-ps compose-status:
 	cd docker && docker compose ps
 
 compose-logs:
-	cd docker && docker compose logs -n 100
+	cd docker && docker compose logs --tail 100
 
 compose-stop compose-down: compose-status
 	cd docker && docker compose down

--- a/server/telemetry-server/app_test.go
+++ b/server/telemetry-server/app_test.go
@@ -278,8 +278,13 @@ func (t *AppTestSuite) TestAuthenticateClientWithInvalidClientId() {
 	rr, err := postToAuthenticateClientHandler(body, t)
 	assert.NoError(t.T(), err)
 
-	assert.Equal(t.T(), 400, rr.Code)
+	assert.Equal(t.T(), 401, rr.Code)
 
+	wwwAuthList, ok := rr.Result().Header[http.CanonicalHeaderKey("WWW-Authenticate")]
+	assert.True(t.T(), ok, "missing WWW-Authenticate header")
+	assert.True(t.T(), strings.Contains(wwwAuthList[0], "Bearer"), "WWW-Authenticate should contain Bearer challenge")
+	assert.True(t.T(), strings.Contains(wwwAuthList[0], `realm="suse-telemetry-service"`), "WWW-Authenticate should contain correct realm")
+	assert.True(t.T(), strings.Contains(wwwAuthList[0], `scope="register"`), "WWW-Authenticate should contain correct scope")
 }
 
 func (t *AppTestSuite) TestAuthenticateClientWithUnregisteredClientId() {
@@ -293,6 +298,11 @@ func (t *AppTestSuite) TestAuthenticateClientWithUnregisteredClientId() {
 
 	assert.Equal(t.T(), 401, rr.Code)
 
+	wwwAuthList, ok := rr.Result().Header[http.CanonicalHeaderKey("WWW-Authenticate")]
+	assert.True(t.T(), ok, "missing WWW-Authenticate header")
+	assert.True(t.T(), strings.Contains(wwwAuthList[0], "Bearer"), "WWW-Authenticate should contain Bearer challenge")
+	assert.True(t.T(), strings.Contains(wwwAuthList[0], `realm="suse-telemetry-service"`), "WWW-Authenticate should contain correct realm")
+	assert.True(t.T(), strings.Contains(wwwAuthList[0], `scope="register"`), "WWW-Authenticate should contain correct scope")
 }
 
 func (t *AppTestSuite) TestAuthenticateClientWithInvalidInstIdHash() {
@@ -384,7 +394,13 @@ func (t *AppTestSuite) TestAuthenticateClientWithEmptyJSON() {
 	body := `{}`
 	rr, err := postToAuthenticateClientHandler(body, t)
 	assert.NoError(t.T(), err)
-	assert.Equal(t.T(), 400, rr.Code)
+	assert.Equal(t.T(), 401, rr.Code)
+
+	wwwAuthList, ok := rr.Result().Header[http.CanonicalHeaderKey("WWW-Authenticate")]
+	assert.True(t.T(), ok, "missing WWW-Authenticate header")
+	assert.True(t.T(), strings.Contains(wwwAuthList[0], "Bearer"), "WWW-Authenticate should contain Bearer challenge")
+	assert.True(t.T(), strings.Contains(wwwAuthList[0], `realm="suse-telemetry-service"`), "WWW-Authenticate should contain correct realm")
+	assert.True(t.T(), strings.Contains(wwwAuthList[0], `scope="register"`), "WWW-Authenticate should contain correct scope")
 }
 
 func postToReportTelemetryHandler(body string, compression string, auth bool, t *AppTestSuite) (*httptest.ResponseRecorder, error) {


### PR DESCRIPTION
Also fix broken tests that snuck through previously when toplevel make wasn't failing for submake failures.

Also use --tail, rather that the -n abbreviated option name, when running docker compose logs for backwards compatibility with older docker compose plugin versions that didn't support the abbreviated name.