### PR TITLE
Rework the client registration workflow and client id

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,11 +19,25 @@ jobs:
         with:
           path: telemetry-server
 
+      - name: Select Telemetry Repo Branch
+        id: telemetry-repo-branch
+        run: |
+          branch="$(echo "${{ github.event.pull_request.body }}" |
+            grep -o "^[[:space:]]*TelemetryRepoBranch: .*$" |
+            cut -d":" -f2 | tr -d '[[:space:]]' || true)"
+          [[ -n "${branch}" ]] || branch=main
+          echo "TelemetryRepoBranch=${branch}" >> "$GITHUB_OUTPUT"
+
+      - name: Show TelemetryRepoBranch
+        run: |
+          echo "TelemetryRepoBranch=${{ steps.telemetry-repo-branch.outputs.TelemetryRepoBranch }}"
+
       - name: Checkout SUSE/telemetry companion sources
         uses: actions/checkout@v4
         with:
           repository: SUSE/telemetry
           path: telemetry
+          ref: "${{ steps.telemetry-repo-branch.outputs.TelemetryRepoBranch }}"
 
       - name: Run tests in verbose mode
         run: cd telemetry-server && make test-verbose

--- a/app/app.go
+++ b/app/app.go
@@ -64,8 +64,8 @@ func (ar *AppRequest) GetAuthToken() string {
 	return strings.TrimPrefix(ar.GetAuthorization(), "Bearer ")
 }
 
-func (ar *AppRequest) GetClientId() string {
-	return ar.GetHeader("X-Telemetry-Client-Id")
+func (ar *AppRequest) GetRegistrationId() string {
+	return ar.GetHeader("X-Telemetry-Registration-Id")
 }
 
 func (ar *AppRequest) SetHeader(header, value string) {

--- a/app/handler_authenticate.go
+++ b/app/handler_authenticate.go
@@ -28,9 +28,9 @@ func (a *App) AuthenticateClient(ar *AppRequest) {
 		ar.ErrorResponse(http.StatusBadRequest, err.Error())
 		return
 	}
-	if caReq.ClientId <= 0 {
+	if caReq.RegistrationId <= 0 {
 		ar.SetWwwAuthRegister()
-		ar.ErrorResponse(http.StatusUnauthorized, "Invalid ClientId value provided")
+		ar.ErrorResponse(http.StatusUnauthorized, "Invalid registrationId value provided")
 		return
 	}
 	ar.Log.Debug("Unmarshaled", slog.Any("caReq", &caReq))
@@ -52,17 +52,17 @@ func (a *App) AuthenticateClient(ar *AppRequest) {
 		return
 	}
 
-	// confirm that the provided clientInstanceId SHA matches the registered one
-	instIdHash := client.ClientInstanceId.Hash(caReq.InstIdHash.Method)
-	if !instIdHash.Match(&caReq.InstIdHash) {
+	// confirm that the provided registration hash matches the registered one
+	regHash := client.GetClientRegistration().Hash(caReq.RegHash.Method)
+	if !regHash.Match(&caReq.RegHash) {
 		ar.Log.Error(
-			"ClientInstanceId hash mismatch",
-			slog.String("Req Hash", caReq.InstIdHash.String()),
-			slog.String("DB Hash", instIdHash.String()),
+			"Registration hash mismatch",
+			slog.String("Req Hash", caReq.RegHash.String()),
+			slog.String("DB Hash", regHash.String()),
 		)
 		// client needs to re-register
 		ar.SetWwwAuthRegister()
-		ar.ErrorResponse(http.StatusUnauthorized, "ClientInstanceId mismatch")
+		ar.ErrorResponse(http.StatusUnauthorized, "Registration mismatch")
 		return
 	}
 
@@ -84,7 +84,7 @@ func (a *App) AuthenticateClient(ar *AppRequest) {
 
 	// initialise a client registration response
 	caResp := restapi.ClientAuthenticationResponse{
-		ClientId:         client.Id,
+		RegistrationId:   client.Id,
 		AuthToken:        client.AuthToken,
 		RegistrationDate: client.RegistrationDate,
 	}

--- a/app/handler_register.go
+++ b/app/handler_register.go
@@ -49,8 +49,16 @@ func (a *App) RegisterClient(ar *AppRequest) {
 	}
 
 	client.InitRegistration(&crReq)
+	// check if the supplied registration already exists, e.g. cloned system
 	if client.RegistrationExists() {
 		ar.ErrorResponse(http.StatusConflict, "specified registration already exists")
+		return
+	}
+
+	// check if the supplied registration's clientID already exists, e.g. a new
+	// client generated the same UUID value that an existing client is using
+	if client.ClientIdExists() {
+		ar.ErrorResponse(http.StatusConflict, "specified registration clientId already exists")
 		return
 	}
 

--- a/app/handler_register.go
+++ b/app/handler_register.go
@@ -29,8 +29,13 @@ func (a *App) RegisterClient(ar *AppRequest) {
 		ar.ErrorResponse(http.StatusBadRequest, err.Error())
 		return
 	}
-	if string(crReq.ClientInstanceId) == "" {
-		ar.ErrorResponse(http.StatusBadRequest, "no ClientInstanceId value provided")
+	// verify that clientId and timestamp are specified in registration
+	if string(crReq.ClientRegistration.ClientId) == "" {
+		ar.ErrorResponse(http.StatusBadRequest, "missing registration clientId")
+		return
+	}
+	if string(crReq.ClientRegistration.Timestamp) == "" {
+		ar.ErrorResponse(http.StatusBadRequest, "missing registration timestamp")
 		return
 	}
 	ar.Log.Debug("Unmarshaled", slog.Any("crReq", &crReq))
@@ -44,8 +49,8 @@ func (a *App) RegisterClient(ar *AppRequest) {
 	}
 
 	client.InitRegistration(&crReq)
-	if client.InstIdExists() {
-		ar.ErrorResponse(http.StatusConflict, "specified clientInstanceId already exists")
+	if client.RegistrationExists() {
+		ar.ErrorResponse(http.StatusConflict, "specified registration already exists")
 		return
 	}
 
@@ -63,7 +68,7 @@ func (a *App) RegisterClient(ar *AppRequest) {
 
 	// initialise a client registration response
 	crResp := restapi.ClientRegistrationResponse{
-		ClientId:         client.Id,
+		RegistrationId:   client.Id,
 		AuthToken:        client.AuthToken,
 		RegistrationDate: client.RegistrationDate,
 	}

--- a/app/handler_report.go
+++ b/app/handler_report.go
@@ -16,11 +16,11 @@ func (a *App) ReportTelemetry(ar *AppRequest) {
 	ar.Log.Info("Processing")
 
 	// retrieve required headers
-	hdrClientId := ar.GetClientId()
+	hdrRegistrationId := ar.GetRegistrationId()
 	token := ar.GetAuthToken()
 
-	// missing clientId or token suggests client needs to register
-	if (hdrClientId == "") || (token == "") {
+	// missing registrationId or token suggests client needs to register
+	if (hdrRegistrationId == "") || (token == "") {
 		// client needs to register
 		ar.SetWwwAuthRegister()
 		ar.ErrorResponse(http.StatusUnauthorized, "Client registration required")
@@ -40,12 +40,12 @@ func (a *App) ReportTelemetry(ar *AppRequest) {
 		slog.String("token", token),
 	)
 
-	// verify that the provided client id is a valid number
-	clientId, err := strconv.ParseInt(hdrClientId, 0, 64)
+	// verify that the provided registration id is a valid number
+	registrationId, err := strconv.ParseInt(hdrRegistrationId, 0, 64)
 	if err != nil {
 		// client needs to register
 		ar.SetWwwAuthRegister()
-		ar.ErrorResponse(http.StatusUnauthorized, "Invalid Client Id")
+		ar.ErrorResponse(http.StatusUnauthorized, "Invalid Registration Id")
 		return
 	}
 
@@ -57,11 +57,11 @@ func (a *App) ReportTelemetry(ar *AppRequest) {
 		return
 	}
 
-	client.InitClientId(clientId)
+	client.InitRegistrationId(registrationId)
 	if !client.Exists() {
 		// client needs to register
 		ar.SetWwwAuthRegister()
-		ar.ErrorResponse(http.StatusUnauthorized, "Invalid Client Id")
+		ar.ErrorResponse(http.StatusUnauthorized, "Invalid Registration Id")
 		return
 	}
 
@@ -76,8 +76,8 @@ func (a *App) ReportTelemetry(ar *AppRequest) {
 	}
 
 	ar.Log.Debug(
-		"Client Authorizated",
-		slog.Int64("clientId", clientId),
+		"Client Authorized",
+		slog.Int64("registrationId", registrationId),
 	)
 
 	// handle payload compression

--- a/app/staging.go
+++ b/app/staging.go
@@ -22,7 +22,7 @@ func (a *App) StageTelemetryReport(reqBody []byte, rHeader *telemetrylib.Telemet
 	}
 
 	reportStagingRow.Init(
-		fmt.Sprintf("%d", rHeader.ReportClientId),
+		fmt.Sprintf("%q", rHeader.ReportClientId),
 		rHeader.ReportId,
 		reqBody,
 	)

--- a/app/telemetry.go
+++ b/app/telemetry.go
@@ -78,7 +78,7 @@ var telemetryTableSpec = TableSpec{
 	Name: "telemetryData",
 	Columns: []TableSpecColumn{
 		{Name: "id", Type: "INTEGER", PrimaryKey: true, Identity: true},
-		{Name: "clientId", Type: "INTEGER"},
+		{Name: "clientId", Type: "VARCHAR"},
 		{Name: "customerId", Type: "INTEGER"},
 		{Name: "telemetryId", Type: "VARCHAR"},
 		{Name: "telemetryType", Type: "VARCHAR"},
@@ -93,7 +93,7 @@ type TelemetryDataRow struct {
 
 	// public table fields
 	Id            int64  `json:"id"`
-	ClientId      int64  `json:"clientId"`
+	ClientId      string `json:"clientId"`
 	CustomerId    string `json:"customerId"`
 	TelemetryId   string `json:"telemetryId"`
 	TelemetryType string `json:"telemetryType"`
@@ -189,7 +189,7 @@ func (t *TelemetryDataRow) Exists() bool {
 			slog.Error(
 				"check for matching entry failed",
 				slog.String("table", t.TableName()),
-				slog.Int64("clientId", t.ClientId),
+				slog.String("clientId", t.ClientId),
 				slog.String("telemetryId", t.TelemetryId),
 				slog.String("timestamp", t.Timestamp),
 				slog.String("error", err.Error()),
@@ -238,7 +238,7 @@ func (t *TelemetryDataRow) Insert() (err error) {
 		slog.Error(
 			"insert failed",
 			slog.String("table", t.TableName()),
-			slog.Int64("clientId", t.ClientId),
+			slog.String("clientId", t.ClientId),
 			slog.String("telemetryId", t.TelemetryId),
 			slog.String("timestamp", t.Timestamp),
 			slog.String("error", err.Error()),

--- a/server/telemetry-admin/app_test.go
+++ b/server/telemetry-admin/app_test.go
@@ -19,14 +19,14 @@ import (
 
 type AppTestSuite struct {
 	suite.Suite
-	app              *app.App
-	config           *app.Config
-	router           *mux.Router
-	path             string
-	authToken        string
-	clientInstanceId types.ClientInstanceId
-	clientInstIdHash types.ClientInstanceIdHash
-	clientId         int64
+	app           *app.App
+	config        *app.Config
+	router        *mux.Router
+	path          string
+	authToken     string
+	clientReg     types.ClientRegistration
+	clientRegHash types.ClientRegistrationHash
+	regId         int64
 }
 
 // run before each test
@@ -74,23 +74,31 @@ auth:
 
 	// setup the client entry in the clients table
 	s.authToken, _ = s.app.AuthManager.CreateToken()
-	s.clientInstanceId = `PQR0123456789`
-	s.clientInstIdHash = types.ClientInstanceIdHash{
+	s.clientReg = types.ClientRegistration{
+		ClientId:   "1b504dca-bd71-424f-87f6-21eb7f5745db",
+		SystemUUID: "3f97d439-5212-4688-af22-ad0559a626cb",
+		Timestamp:  "2024-06-30T23:59:59.999999999Z",
+	}
+	s.clientRegHash = types.ClientRegistrationHash{
 		Method: "sha256",
-		Value:  "279b3ce1c73f3598ee36cde0a38fa6687aa33f50935a8b10a0a6608d3084d22a",
+		Value:  "56dad39883e6b69e68523e8991a9237422a13031fd5f136286045a3e9b79f3ce",
 	}
 	row := s.app.OperationalDB.Conn.QueryRow(
 		`INSERT INTO clients(`+
-			`clientInstanceId, `+
+			`clientId, `+
+			`systemUUID, `+
+			`clientTimestamp, `+
 			`registrationDate, `+
 			`authToken) `+
-			`VALUES(?, ?, ?) `+
+			`VALUES(?, ?, ?, ?, ?) `+
 			`RETURNING id`,
-		string(s.clientInstanceId),
+		s.clientReg.ClientId,
+		s.clientReg.SystemUUID,
+		s.clientReg.Timestamp,
 		"2024-07-01T00:00:00.000000000Z",
 		s.authToken,
 	)
-	if err := row.Scan(&s.clientId); err != nil {
+	if err := row.Scan(&s.regId); err != nil {
 		panic(fmt.Errorf("failed to setup test client entry in clients table: %s", err.Error()))
 	}
 }


### PR DESCRIPTION
TelemetryRepoBranch: client_customer_id_refinements

Previously the client id value in telemetry reports and bundles was the unique id assigned to a telemery client when it registered with and upstream telemetry service, whether gateway or relay. With these changes the client id becomes an UUID string generated by telemetry clients when they first register with an upstream telemetry server.

Previously when a telemetry client was registering with an upstream telemetry service it will include a client instance id arbitrary string value that was intended to uniquely identify the client. With this update, telemetry clients will instead generated a UUID value, their client id, to be included in their registration requests, along with a timestamp and an option systemUUID value. The latter fields can be used to differentiate between telemetry clients that have generated the same client id value, in those rare cases where this happens.

Then result of a regsiter request now includes a unique registration id value, rather than a client id, and subsequent requests from the client should include this value as an X-Telemetry-Registration-Id header value rather than the X-Telemetry-Client-Id header.

The clients table schema has been updated to store the client id, systemUUID and timestamp values supplied as part of a register request.

The telemetry table schema has been updated to store the client id as a string value, rather than an integer.

Updated the GitHub PR testing workflow to allow specifying the branch of the SUSE/telemetry to use when running tests.