### PR TITLE
Address Customer identification mapping

### DIFF
--- a/Makefile.generate
+++ b/Makefile.generate
@@ -27,4 +27,8 @@ check-telemetry-cloned:
 generate: server-healthy check-telemetry-cloned
 	mkdir -p /tmp/susetelemetry
 	cd ../telemetry/cmd/generator; \
-	go run . --config ../../testdata/config/localClient.yaml --telemetry=SLE-SERVER-SCCHwInfo --tag DEVTEST ../../testdata/telemetry/SLE-SERVER-SCCHwInfo/sle12sp5-test.json
+	go run . $(if $(filter debug,$(LOG_LEVEL)),--debug) \
+		--config ../../testdata/config/localClient.yaml \
+		--telemetry=SLE-SERVER-SCCHwInfo \
+		--tag DEVTEST \
+		../../testdata/telemetry/SLE-SERVER-SCCHwInfo/sle12sp5-test.json

--- a/Makefile.golang
+++ b/Makefile.golang
@@ -1,3 +1,5 @@
+COVERAGE_PROFILE=/tmp/.coverage.telemetry-server.out
+
 .DEFAULT_GOAL := build
 
 .PHONY: fmt vet build build-only clean test-clean test-verbose
@@ -23,7 +25,8 @@ test: test-clean build
 	go test -cover ./...
 
 test-verbose: test-clean build
-	go test -v -cover ./...
+	go test -v -cover -coverprofile=$(COVERAGE_PROFILE) ./... && \
+	go tool cover --func=$(COVERAGE_PROFILE)
 
 tidy:
 	go mod tidy

--- a/app/clients.go
+++ b/app/clients.go
@@ -116,9 +116,7 @@ func (c *ClientsRow) Exists() bool {
 			slog.Error(
 				"check for matching entry failed",
 				slog.String("table", c.TableName()),
-				slog.String("clientId", c.ClientId),
-				slog.String("systemUUID", c.SystemUUID),
-				slog.String("clientTimestamp", c.ClientTimestamp),
+				slog.Int64("id", c.Id),
 				slog.String("error", err.Error()),
 			)
 		}

--- a/app/customers.go
+++ b/app/customers.go
@@ -1,0 +1,255 @@
+package app
+
+import (
+	"database/sql"
+	"encoding/json"
+	"log/slog"
+)
+
+// customers table specification
+// The customers table records customer identifiers that have been received
+// in telemetry submissions, and which will be referenced by a customerRefId
+// foreign key reference in the telemetry data table.
+// Additionally a customer identifier entry can be marked as deleted, with
+// an associated deletedAt time. Optionally the associated customerId value
+// can be cleared or changed to an anonymised value as part of marking an
+// entry as deleted.
+var customersTableSpec = TableSpec{
+	Name: "customers",
+	Columns: []TableSpecColumn{
+		{Name: "id", Type: "INTEGER", PrimaryKey: true, Identity: true},
+		{Name: "customerId", Type: "VARCHAR", Nullable: true},
+		{Name: "deleted", Type: "BOOLEAN", Default: "false"},
+		{Name: "deletedAt", Type: "VARCHAR", Nullable: true},
+	},
+}
+
+type CustomersRow struct {
+	// include common table row fields
+	TableRowCommon
+
+	Id         int64  `json:"id"`
+	CustomerId string `json:"customerId"`
+	Deleted    bool   `json:"deleted"`
+	DeletedAt  string `json:"deletedAt"`
+}
+
+func (r *CustomersRow) Init(customerId string) {
+	r.CustomerId = customerId
+}
+
+func (r *CustomersRow) SetupDB(db *DbConnection) (err error) {
+	r.tableSpec = &customersTableSpec
+	return r.TableRowCommon.SetupDB(db)
+}
+
+func (r *CustomersRow) TableName() string {
+	return r.TableRowCommon.TableName()
+}
+
+func (r *CustomersRow) String() string {
+	bytes, _ := json.Marshal(r)
+	return string(bytes)
+}
+
+func (r *CustomersRow) RowId() int64 {
+	return r.Id
+}
+
+func (r *CustomersRow) Exists() bool {
+	stmt, err := r.SelectStmt(
+		// select columns
+		[]string{
+			"id",
+			"deletedAt",
+		},
+		// match columns
+		[]string{
+			"customerId",
+			"deleted",
+		},
+		SelectOpts{}, // no special options
+	)
+	if err != nil {
+		slog.Error(
+			"exists statement generation failed",
+			slog.String("table", r.TableName()),
+			slog.String("error", err.Error()),
+		)
+		panic(err)
+	}
+
+	row := r.DB().QueryRow(stmt, r.CustomerId, r.Deleted)
+	// if the entry was found, all fields not used to find the entry will have
+	// been updated to match what is in the DB
+	if err := row.Scan(
+		&r.Id,
+		&r.DeletedAt,
+	); err != nil {
+		if err != sql.ErrNoRows {
+			slog.Error(
+				"check for matching entry failed",
+				slog.String("table", r.TableName()),
+				slog.Int64("id", r.Id),
+				slog.String("error", err.Error()),
+			)
+		}
+		return false
+	}
+	return true
+}
+
+func (r *CustomersRow) IdExists() bool {
+	stmt, err := r.SelectStmt(
+		// select columns
+		[]string{
+			"customerId",
+			"deleted",
+			"deletedAt",
+		},
+		// match columns
+		[]string{
+			"id",
+		},
+		SelectOpts{}, // no special options
+	)
+	if err != nil {
+		slog.Error(
+			"exists statement generation failed",
+			slog.String("table", r.TableName()),
+			slog.String("error", err.Error()),
+		)
+		panic(err)
+	}
+
+	row := r.DB().QueryRow(stmt, r.Id)
+	// if the entry was found, all fields not used to find the entry will have
+	// been updated to match what is in the DB
+	if err := row.Scan(
+		&r.CustomerId,
+		&r.Deleted,
+		&r.DeletedAt,
+	); err != nil {
+		if err != sql.ErrNoRows {
+			slog.Error(
+				"check for matching entry failed",
+				slog.String("table", r.TableName()),
+				slog.Int64("id", r.Id),
+				slog.String("error", err.Error()),
+			)
+		}
+		return false
+	}
+	return true
+}
+
+func (r *CustomersRow) Insert() (err error) {
+	stmt, err := r.InsertStmt(
+		[]string{
+			"customerId",
+			"deleted",
+			"deletedAt",
+		},
+		"id",
+	)
+	if err != nil {
+		slog.Error(
+			"insert statement generation failed",
+			slog.String("table", r.TableName()),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+	row := r.DB().QueryRow(
+		stmt,
+		r.CustomerId,
+		r.Deleted,
+		r.DeletedAt,
+	)
+	if err = row.Scan(
+		&r.Id,
+	); err != nil {
+		slog.Error(
+			"insert failed",
+			slog.String("table", r.TableName()),
+			slog.String("customerId", r.CustomerId),
+			slog.Bool("deleted", r.Deleted),
+			slog.String("deletedAt", r.DeletedAt),
+			slog.String("error", err.Error()),
+		)
+	}
+
+	return
+}
+
+func (r *CustomersRow) Update() (err error) {
+	stmt, err := r.UpdateStmt(
+		[]string{
+			"customerId",
+			"deleted",
+			"deletedAt",
+		},
+		[]string{
+			"id",
+		},
+	)
+	if err != nil {
+		slog.Error(
+			"update statement generation failed",
+			slog.String("table", r.TableName()),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+	_, err = r.DB().Exec(
+		stmt,
+		r.CustomerId,
+		r.Deleted,
+		r.DeletedAt,
+		r.Id,
+	)
+	if err != nil {
+		slog.Error(
+			"update failed",
+			slog.String("table", r.TableName()),
+			slog.Int64("id", r.Id),
+			slog.String("error", err.Error()),
+		)
+	}
+
+	return
+}
+
+func (r *CustomersRow) Delete() (err error) {
+	stmt, err := r.DeleteStmt(
+		[]string{
+			"id",
+		},
+	)
+	if err != nil {
+		slog.Error(
+			"delete statement generation failed",
+			slog.String("table", r.TableName()),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+
+	_, err = r.DB().Exec(
+		stmt,
+		r.Id,
+	)
+	if err != nil {
+		slog.Error(
+			"delete failed",
+			slog.String("table", r.TableName()),
+			slog.Int64("id", r.Id),
+			slog.String("error", err.Error()),
+		)
+	}
+
+	return
+}
+
+// verify that CustomersRow conforms to the TableRowHandler interface
+var _ TableRowHandler = (*CustomersRow)(nil)

--- a/app/handler_report.go
+++ b/app/handler_report.go
@@ -114,7 +114,11 @@ func (a *App) ReportTelemetry(ar *AppRequest) {
 	ar.Log.Debug("Unmarshaled", slog.Any("trReq", &trReq))
 
 	// save the report into the staging db
-	a.StageTelemetryReport(reqBody, &trReq.TelemetryReport.Header)
+	err = a.StageTelemetryReport(reqBody, &trReq.TelemetryReport.Header)
+	if err != nil {
+		ar.ErrorResponse(http.StatusBadRequest, err.Error())
+		return
+	}
 
 	// process pending reports
 	a.ProcessStagedReports()

--- a/app/tables.go
+++ b/app/tables.go
@@ -12,6 +12,7 @@ var operationalTables = []TableSpec{
 
 // Telemetry DB Tables
 var telemetryTables = []TableSpec{
+	customersTableSpec,
 	tagSetsTableSpec,
 	telemetryTableSpec,
 }

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -37,6 +37,8 @@ services:
     ports:
       - "9998:9998"
     depends_on:
+      tsg:
+        condition: service_healthy
       db:
         condition: service_healthy
     healthcheck:


### PR DESCRIPTION
Add a new customers table which is used to manage customerIds that are provided in telemetry submissions.

Update the telemetry data storage handling to obtain the appropriate customerRefId for a bundle's customer id.

Update the database table definition and management routines with support for specifying foreign keys via a new ForeignKeys field in the TableSpec structure.

Restore the telemetrydata table foreign key definition for tagSetId targetting the id field of the tagsets table.

Update telemetrydata table definition to replace the customerId field with a customerRefId field that is a foreign key reference to the associated id field in the new customers table.

Ensure failures adding a report to the reports table are handled appropriately, resulting in a failed /report request.

Fix ClientsRow.Exists() error message to match what the routine is doing.

Make target enhancements:
* generate now support LOG_LEVEL specification
* test-verbose shows detailed coverage statistics

Add a dependency for the Telemetry Admin service on the Telemetry Gateway service in the docker/compose.yaml to avoid racing attempts to initialise the table definitions in the backend postgres database.