### PR TITLE
Drop the separate staging database

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,11 +117,9 @@ db-1   | 2024-08-01 14:19:45.222 UTC [1] LOG:  listening on IPv6 address "::", p
 db-1   | 2024-08-01 14:19:45.224 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
 db-1   | 2024-08-01 14:19:45.230 UTC [72] LOG:  database system was shut down at 2024-08-01 14:19:45 UTC
 db-1   | 2024-08-01 14:19:45.236 UTC [1] LOG:  database system is ready to accept connections
-tsa-1  | time=2024-08-01T14:19:46.002Z level=INFO msg="Database Connected" database=Staging
 tsa-1  | time=2024-08-01T14:19:46.005Z level=INFO msg="Database Connected" database=Operational
 tsa-1  | time=2024-08-01T14:19:46.030Z level=INFO msg="Database Connected" database=Telemetry
 tsa-1  | time=2024-08-01T14:19:46.041Z level=INFO msg="Starting Telemetry Admin" listenOn=tsa:9998
-tsg-1  | time=2024-08-01T14:19:52.043Z level=INFO msg="Database Connected" database=Staging
 tsg-1  | time=2024-08-01T14:19:52.047Z level=INFO msg="Database Connected" database=Operational
 tsg-1  | time=2024-08-01T14:19:52.061Z level=INFO msg="Database Connected" database=Telemetry
 tsg-1  | time=2024-08-01T14:19:52.069Z level=INFO msg="Starting Telemetry Server" listenOn=tsg:9999
@@ -201,7 +199,6 @@ To check the logs of the telemetry-server:
 docker logs -n 100 telemetry-server
 time=2024-07-12T12:15:51.633Z level=INFO msg="Logging initialised" level=INFO dest=stderr style=TEXT
 time=2024-07-12T12:15:51.633Z level=INFO msg="Logging initialised" level=INFO dest=stderr style=TEXT
-time=2024-07-12T12:15:51.633Z level=INFO msg="Database Connected" database=Staging
 time=2024-07-12T12:15:51.638Z level=INFO msg="Database Connected" database=Operational
 time=2024-07-12T12:15:51.641Z level=INFO msg="Database Connected" database=Telemetry
 time=2024-07-12T12:15:51.653Z level=INFO msg="Starting Telemetry Server" listenOn=0.0.0.0:9999

--- a/app/app.go
+++ b/app/app.go
@@ -177,7 +177,6 @@ type App struct {
 	Config        *Config
 	TelemetryDB   DbConnection
 	OperationalDB DbConnection
-	StagingDB     DbConnection
 	Address       ServerAddress
 	Handler       http.Handler
 	LogManager    *logging.LogManager
@@ -206,7 +205,6 @@ func NewApp(name string, cfg *Config, handler http.Handler, debugMode bool) *App
 	// setup databases
 	a.TelemetryDB.Setup("Telemetry", cfg.DataBases.Telemetry)
 	a.OperationalDB.Setup("Operational", cfg.DataBases.Operational)
-	a.StagingDB.Setup("Staging", cfg.DataBases.Staging)
 
 	// setup address
 	a.Address.Setup(cfg.API)
@@ -255,17 +253,6 @@ func (a *App) ListenOn() string {
 }
 
 func (a *App) Initialize() error {
-
-	// staging DB setup
-	if err := a.StagingDB.Connect(); err != nil {
-		slog.Error("Staging DB connection setup failed", slog.String("error", err.Error()))
-		return err
-	}
-
-	if err := a.StagingDB.EnsureTableSpecsExist(stagingTables); err != nil {
-		slog.Error("Staging DB tables setup failed", slog.String("error", err.Error()))
-		return err
-	}
 
 	// operational DB setup
 	if err := a.OperationalDB.Connect(); err != nil {
@@ -325,7 +312,6 @@ func (a *App) Shutdown() (err error) {
 	// close the DB connections
 	dbConns := []DbConnection{
 		a.TelemetryDB,
-		a.StagingDB,
 		a.OperationalDB,
 	}
 	for _, dbConn := range dbConns {

--- a/app/config.go
+++ b/app/config.go
@@ -61,7 +61,6 @@ type Config struct {
 	DataBases struct {
 		Telemetry   DBConfig `yaml:"telemetry"`
 		Operational DBConfig `yaml:"operational"`
-		Staging     DBConfig `yaml:"staging"`
 	} `yaml:"dbs"`
 	// logging config settings
 	Logging config.LogConfig `yaml:"logging"`

--- a/app/handler_report.go
+++ b/app/handler_report.go
@@ -121,7 +121,7 @@ func (a *App) ReportTelemetry(ar *AppRequest) {
 	}
 	ar.Log.Debug("Checksums verified")
 
-	// save the report into the staging db
+	// save the report into the operational db
 	err = a.StageTelemetryReport(reqBody, &trReq.TelemetryReport.Header)
 	if err != nil {
 		ar.ErrorResponse(http.StatusBadRequest, err.Error())

--- a/app/staging.go
+++ b/app/staging.go
@@ -11,12 +11,12 @@ import (
 )
 
 func (a *App) StageTelemetryReport(reqBody []byte, rHeader *telemetrylib.TelemetryReportHeader) (err error) {
-	// Stores the report body into the staging database in the reports table
+	// Stores the report body in the operational database's reports table
 
 	// create a ReportStagingTableRow struct
 
 	reportStagingRow := new(ReportStagingTableRow)
-	if err = reportStagingRow.SetupDB(&a.StagingDB); err != nil {
+	if err = reportStagingRow.SetupDB(&a.OperationalDB); err != nil {
 		slog.Error("ReportStagingTableRow.SetupDB failed", slog.String("error", err.Error()))
 		return
 	}
@@ -36,7 +36,7 @@ func (a *App) StageTelemetryReport(reqBody []byte, rHeader *telemetrylib.Telemet
 
 func (a *App) ProcessStagedReports() {
 	reportRow := new(ReportStagingTableRow)
-	reportRow.SetupDB(&a.StagingDB)
+	reportRow.SetupDB(&a.OperationalDB)
 
 	for reportRow.FirstUnallocated() {
 		err := a.ProcessStagedReport(reportRow)

--- a/app/tables.go
+++ b/app/tables.go
@@ -1,12 +1,8 @@
 package app
 
-// Staging DB Tables
-var stagingTables = []TableSpec{
-	reportsStagingTableSpec,
-}
-
 // Operational DB Tables
 var operationalTables = []TableSpec{
+	reportsStagingTableSpec,
 	clientsTableSpec,
 }
 

--- a/charts/telemetry-server/templates/rdsconfigmap.yaml
+++ b/charts/telemetry-server/templates/rdsconfigmap.yaml
@@ -14,14 +14,6 @@ data:
     SELECT 'CREATE USER bi_team WITH PASSWORD ''__BI_TEAM_PASSWORD__'''
     WHERE NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = 'bi_team')\gexec
 
-    -- Create staging database and grant user access
-    SELECT 'CREATE DATABASE staging WITH TEMPLATE template0'
-    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'staging')\gexec
-    \c staging
-    GRANT ALL ON SCHEMA public TO telemetry;
-    GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO telemetry;
-    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO telemetry;
-
     -- Create operational database and grant user access
     SELECT 'CREATE DATABASE operational WITH TEMPLATE template0'
     WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname= 'operational')\gexec

--- a/charts/telemetry-server/values.yaml
+++ b/charts/telemetry-server/values.yaml
@@ -143,9 +143,6 @@ config:
     operational:
       driver: postgres
       params: "<OPERATIONAL_DB_CONNECTION_STRING>"
-    staging:
-      driver: postgres
-      params: "<STAGING_DB_CONNECTION_STRING>"
   logging:
     level: debug
     location: stderr

--- a/docker/postgres/telemetry/init.sql.template
+++ b/docker/postgres/telemetry/init.sql.template
@@ -6,14 +6,6 @@ WHERE NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = 'telemetry')\g
 SELECT 'CREATE USER bi_team WITH PASSWORD ''__BI_TEAM_PASSWORD__'''
 WHERE NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = 'bi_team')\gexec
 
--- Create staging database and grant telemetry user access
-SELECT 'CREATE DATABASE staging WITH TEMPLATE template0'
-WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'staging')\gexec
-\c staging
-GRANT ALL ON SCHEMA public TO telemetry;
-GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO telemetry;
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO telemetry;
-
 -- Create operational database and grant telemetry user access
 SELECT 'CREATE DATABASE operational WITH TEMPLATE template0'
 WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'operational')\gexec

--- a/server/telemetry-admin/app_test.go
+++ b/server/telemetry-admin/app_test.go
@@ -51,16 +51,13 @@ dbs:
   operational:
     driver: sqlite3
     params: %s/operational.db
-  staging:
-    driver: sqlite3
-    params: %s/staging.db
 logging:
   level: debug
 auth:
   secret: VGVzdGluZ1NlY3JldAo=
 `
 
-	formattedContents := fmt.Sprintf(content, s.path, s.path, s.path)
+	formattedContents := fmt.Sprintf(content, s.path, s.path)
 	_, err = tmpfile.Write([]byte(formattedContents))
 	require.NoError(s.T(), err)
 	require.NoError(s.T(), tmpfile.Close())

--- a/server/telemetry-server/app_test.go
+++ b/server/telemetry-server/app_test.go
@@ -61,16 +61,13 @@ dbs:
   operational:
     driver: sqlite3
     params: %s/operational.db
-  staging:
-    driver: sqlite3
-    params: %s/staging.db
 logging:
   level: debug
 auth:
   secret: VGVzdGluZ1NlY3JldAo=
 `
 
-	formattedContents := fmt.Sprintf(content, s.path, s.path, s.path)
+	formattedContents := fmt.Sprintf(content, s.path, s.path)
 	_, err = tmpfile.Write([]byte(formattedContents))
 	require.NoError(s.T(), err)
 	require.NoError(s.T(), tmpfile.Close())

--- a/testdata/config/composeAdmin.yaml
+++ b/testdata/config/composeAdmin.yaml
@@ -8,9 +8,6 @@ dbs:
   operational:
     driver: postgres
     params: "postgres://telemetry:test@db:5432/operational"
-  staging:
-    driver: postgres
-    params: "postgres://telemetry:test@db:5432/staging"
 logging:
   level: info
   location: stderr

--- a/testdata/config/composeServer.yaml
+++ b/testdata/config/composeServer.yaml
@@ -8,9 +8,6 @@ dbs:
   operational:
     driver: postgres
     params: "postgres://telemetry:test@db:5432/operational"
-  staging:
-    driver: postgres
-    params: "postgres://telemetry:test@db:5432/staging"
 logging:
   level: info
   location: stderr

--- a/testdata/config/dockerAdmin.yaml
+++ b/testdata/config/dockerAdmin.yaml
@@ -8,9 +8,6 @@ dbs:
   operational:
     driver: sqlite3
     params: /var/lib/tsvc/data/operational.db
-  staging:
-    driver: sqlite3
-    params: /var/lib/tsvc/data/staging.db
 logging:
   level: info
   location: stderr

--- a/testdata/config/dockerServer.yaml
+++ b/testdata/config/dockerServer.yaml
@@ -8,9 +8,6 @@ dbs:
   operational:
     driver: sqlite3
     params: /var/lib/tsvc/data/operational.db
-  staging:
-    driver: sqlite3
-    params: /var/lib/tsvc/data/staging.db
 logging:
   level: info
   location: stderr

--- a/testdata/config/localAdmin.yaml
+++ b/testdata/config/localAdmin.yaml
@@ -8,9 +8,6 @@ dbs:
   operational:
     driver: sqlite3
     params: /tmp/telemetry/server/operational.db
-  staging:
-    driver: sqlite3
-    params: /var/lib/tsvc/data/staging.db
 logging:
   level: info
   location: stderr

--- a/testdata/config/localServer.yaml
+++ b/testdata/config/localServer.yaml
@@ -8,9 +8,6 @@ dbs:
   operational:
     driver: sqlite3
     params: /tmp/telemetry/server/operational.db
-  staging:
-    driver: sqlite3
-    params: /tmp/telemetry/server/staging.db
 logging:
   level: info
   location: stderr


### PR DESCRIPTION
Move the reports staging table into the operational database and remove the need for a separate staging database.