### PR TITLE
Use upstream telemetry repo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,14 @@ jobs:
           ref: "${{ needs.telemetry_repo_branch.outputs.telemetryRepoBranch }}"
 
       - name: Run tests in verbose mode
-        run: cd telemetry-server && make test-verbose
+        run: |
+          cd telemetry-server && \
+          if [[ "${{ needs.telemetry_repo_branch.outputs.telemetryRepoBranch }}" != "main" ]]; then \
+            go mod edit --replace \
+                github.com/SUSE/telemetry=../telemetry/ && \
+            make mod-tidy; \
+          fi && \
+          make test-verbose
 
   e2e:
     name: Run basic end to end tests

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ export GO_COVERAGE_PROFILE = /tmp/.coverage.telemetry-server.out
 
 ifeq ($(MAKELEVEL),0)
 
-LOG_LEVEL=info
+LOG_LEVEL = info
 CNTR_MGR = docker
-TELEMETRY_REPO_BRANCH = main
+TELEMETRY_REPO_BRANCH ?= main
 
 include Makefile.local-server
 include Makefile.compose

--- a/Makefile.compose
+++ b/Makefile.compose
@@ -8,7 +8,9 @@ PG_DOCKER_VOLUME = docker_pgdata
 compose-build: vet
 	cd docker && $(CNTR_MGR) compose build \
 		--build-arg logLevel=$(LOG_LEVEL) \
-		--build-arg telemetryRepoBranch=$(TELEMETRY_REPO_BRANCH)
+		--build-arg telemetryCfgDir=/etc/susetelemetry \
+		--build-arg telemetryRepoBranch=$(TELEMETRY_REPO_BRANCH) \
+		--build-arg telemetryImageVariant=$(if $(filter-out main,$(TELEMETRY_REPO_BRANCH)),specified,upstream)
 
 compose-start compose-up: compose-build
 	cd docker && $(CNTR_MGR) compose --parallel 4 up --wait -d

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -14,7 +14,8 @@ docker-build: vet
 		$(CNTR_MGR) build -t $${cntr} --target $${cntr} . \
 		  --build-arg logLevel=$(LOG_LEVEL) \
 		  --build-arg telemetryCfgDir=/etc/susetelemetry \
-			--build-arg telemetryRepoBranch=$(TELEMETRY_REPO_BRANCH); \
+			--build-arg telemetryRepoBranch=$(TELEMETRY_REPO_BRANCH) \
+			--build-arg telemetryImageVariant=$(if $(filter-out main,$(TELEMETRY_REPO_BRANCH)),specified,upstream); \
 	done
 
 docker-start docker-run: docker-build

--- a/Makefile.local-server
+++ b/Makefile.local-server
@@ -1,16 +1,39 @@
-TELEMETRY_SERVER = server/telemetry-server
+REPO_DIR = $(patsubst %/,%,$(strip $(dir $(realpath $(lastword $(MAKEFILE_LIST))))))
 TELEMETRY_TMP = /tmp/telemetry
-TELEMETRY_SERVER_TMP = $(TELEMETRY_TMP)/server
+TELEMETRY_LOCAL= $(TELEMETRY_TMP)/local
+TELEMETRY_SERVER = $(TELEMETRY_TMP)/server
+TELEMETRY_TMP_DIRS = \
+	$(TELEMETRY_LOCAL) \
+	$(TELEMETRY_SERVER)
 
-.PHONY: local-server local-server-cleanup local-server-start
+.PHONY: local-server local-server-cleanup local-server-directories local-server-setup local-server-start local-server-tests
 
 local-server-cleanup:
-	cd $(TELEMETRY_SERVER); \
-	rm -rf $(TELEMETRY_SERVER_TMP)
+	rm -rf $(TELEMETRY_TMP_DIRS)
 
-local-server-start:
-	cd $(TELEMETRY_SERVER); \
-	mkdir -p $(TELEMETRY_SERVER_TMP); \
+local-server-directories: local-server-cleanup
+	set -eu && \
+	mkdir -p $(TELEMETRY_TMP_DIRS) && \
+	cp -a $(REPO_DIR) $(TELEMETRY_LOCAL)/ && \
+	if [ -d $(REPO_DIR)/../telemetry ]; then \
+		cp -a $(REPO_DIR)/../telemetry $(TELEMETRY_LOCAL)/;  \
+	fi
+
+local-server-setup: local-server-directories
+	set -eu && \
+	cd $(TELEMETRY_LOCAL)/telemetry-server && \
+	if [ -d ../telemetry ]; then \
+		go mod edit --replace \
+			github.com/SUSE/telemetry=../telemetry/ && \
+		make mod-tidy; \
+	fi
+
+local-server-tests: local-server-setup
+	cd $(TELEMETRY_LOCAL)/telemetry-server && \
+	make test-verbose
+
+local-server-start: local-server-setup
+	cd $(TELEMETRY_LOCAL)/telemetry-server/server/telemetry-server && \
 	go run . $(if $(filter debug,$(LOG_LEVEL)),--debug) --config ../../testdata/config/localServer.yaml
 
-local-server: local-server-cleanup local-server-start
+local-server: local-server-start

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,8 @@ go 1.23.0
 
 toolchain go1.23.7
 
-replace github.com/SUSE/telemetry => ../telemetry/
-
 require (
-	github.com/SUSE/telemetry v0.1.0
+	github.com/SUSE/telemetry v0.1.1
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/jackc/pgx/v5 v5.7.4
 	github.com/mattn/go-sqlite3 v1.14.24

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/SUSE/telemetry v0.1.1 h1:r0L28N3/cIH2YBauhq6cUOSs9KG0Z+CmyVn6p3C7Z/U=
+github.com/SUSE/telemetry v0.1.1/go.mod h1:0E5LAq/FE7FF8hIuX0hZ+2eo1FbGvLHZUcp25Vf5+iA=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/server/telemetry-admin/go.mod
+++ b/server/telemetry-admin/go.mod
@@ -6,10 +6,7 @@ toolchain go1.23.7
 
 replace github.com/SUSE/telemetry-server => ../../../telemetry-server/
 
-replace github.com/SUSE/telemetry => ../../../telemetry/
-
 require (
-	github.com/go-playground/validator/v10 v10.25.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/mux v1.8.1
 	github.com/stretchr/testify v1.10.0
@@ -17,29 +14,30 @@ require (
 )
 
 require (
-	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
-	github.com/go-playground/locales v0.14.1 // indirect
-	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/leodido/go-urn v1.4.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
-	golang.org/x/net v0.37.0 // indirect
-	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 )
 
 require (
-	github.com/SUSE/telemetry v0.1.0
-	github.com/SUSE/telemetry-server v0.0.0-20250326120051-2c36ac9ea073
+	github.com/SUSE/telemetry v0.1.1
+	github.com/SUSE/telemetry-server v0.0.0-20250326145027-115aa939d8e3
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
+	github.com/go-playground/locales v0.14.1 // indirect
+	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/go-playground/validator/v10 v10.25.0 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgx/v5 v5.7.4 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
+	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-sqlite3 v1.14.24 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/net v0.37.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect
+	golang.org/x/sys v0.31.0 // indirect
 )

--- a/server/telemetry-admin/go.sum
+++ b/server/telemetry-admin/go.sum
@@ -1,3 +1,5 @@
+github.com/SUSE/telemetry v0.1.1 h1:r0L28N3/cIH2YBauhq6cUOSs9KG0Z+CmyVn6p3C7Z/U=
+github.com/SUSE/telemetry v0.1.1/go.mod h1:0E5LAq/FE7FF8hIuX0hZ+2eo1FbGvLHZUcp25Vf5+iA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/server/telemetry-server/go.mod
+++ b/server/telemetry-server/go.mod
@@ -6,10 +6,7 @@ toolchain go1.23.7
 
 replace github.com/SUSE/telemetry-server => ../../../telemetry-server/
 
-replace github.com/SUSE/telemetry => ../../../telemetry/
-
 require (
-	github.com/go-playground/validator/v10 v10.25.0 // indirect
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/stretchr/testify v1.10.0
@@ -17,29 +14,30 @@ require (
 )
 
 require (
-	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
-	github.com/go-playground/locales v0.14.1 // indirect
-	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/leodido/go-urn v1.4.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
-	golang.org/x/net v0.37.0 // indirect
-	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 )
 
 require (
-	github.com/SUSE/telemetry v0.1.0
-	github.com/SUSE/telemetry-server v0.0.0-20250326120051-2c36ac9ea073
+	github.com/SUSE/telemetry v0.1.1
+	github.com/SUSE/telemetry-server v0.0.0-20250326145027-115aa939d8e3
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
+	github.com/go-playground/locales v0.14.1 // indirect
+	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/go-playground/validator/v10 v10.25.0 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgx/v5 v5.7.4 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
+	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-sqlite3 v1.14.24 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/net v0.37.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect
+	golang.org/x/sys v0.31.0 // indirect
 )

--- a/server/telemetry-server/go.sum
+++ b/server/telemetry-server/go.sum
@@ -1,3 +1,5 @@
+github.com/SUSE/telemetry v0.1.1 h1:r0L28N3/cIH2YBauhq6cUOSs9KG0Z+CmyVn6p3C7Z/U=
+github.com/SUSE/telemetry v0.1.1/go.mod h1:0E5LAq/FE7FF8hIuX0hZ+2eo1FbGvLHZUcp25Vf5+iA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/telemetry-server.go
+++ b/telemetry-server.go
@@ -6,4 +6,3 @@ import (
 )
 
 type App = app.App
-


### PR DESCRIPTION
Instead of requiring that github.com/SUSE/telemetry be cloned on the appropriate branch beside the telemetry-server repo, rely on normal mod dependencies to provide the telemetry repo.

Update the go.mod to remove the replace directive for the telemetry repo, and update the go.sum to match the current (v0.1.1) version of the upstream telemetry repo.

Update the Dockerfile build process to optionally clone the telemetry repo and use it as a build input if a branch or tag other than main is specified via the build arguments.

Update Makefile rules to pass the appropriate build args for docker and compose targets if a branch other than main is specified via the TELEMETRY_REPO_BRANCH variable.

Update GitHub Actions ci.yaml workflow to clone and use the telemetry repo to run the source tests if a branch other than main is specified.

Updated local-server make target rules to add support for running both the server and tests using the locally cloned telemetry repo if found. This is achieved by copying the telemetry-server repo, and, if found, the telemetry repo cloned beside it, to a staging directory under /tmp/telemetry/local, adjusting the copied telemetry-server repo's go.mod settings with a appropriate as needed, and then the server or the tests are run from within that staging directory, depending on the specified make target.

Update README.md to reflect these changes.