### PR TITLE
Build telemetry-postgres image ub top-level Dockerfile

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        suffix: [server, admin]
+        suffix: [server, admin, postgres]
 
     steps:
       - name: Checkout Code

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,12 @@
 ARG GO_NO_PROXY=github.com/SUSE
 
 #
+# PostgreSQL Settings
+#
+ARG POSTGRES_BASE=registry.suse.com/suse/postgres
+ARG POSTGRES_MAJOR=16
+
+#
 # Telemetry Build Settings
 #
 ARG telemetryImageVariant=upstream
@@ -30,6 +36,15 @@ ARG gid=1001
 #
 ARG telemetryAdmin=telemetry-admin
 ARG telemetryServer=telemetry-server
+
+#
+# Build the customised telemetry-postgres image
+#
+FROM ${POSTGRES_BASE}:${POSTGRES_MAJOR} AS telemetry-postgres
+
+# add the telemetry init scripting
+ADD docker/postgres/telemetry /telemetry
+RUN chmod +x /telemetry/*.bash
 
 #
 # Build the code in BCI golang based image

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -54,7 +54,8 @@ services:
   db:
     image: telemetry/postgres
     build:
-      context: postgres
+      context: ..
+      target: telemetry-postgres
     restart: always
     networks:
       - internal

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,6 +1,0 @@
-# Use the latest upstream postgres:16 image
-FROM registry.suse.com/suse/postgres:16
-
-# add the telemetry init scripting
-ADD telemetry /telemetry
-RUN chmod +x /telemetry/*.bash


### PR DESCRIPTION
Move building of the telemetry-postgres image within the top-level Dockerfile and update the docker/compose.yaml appropriately.

Update the GHA build workflow to also build the telemetry-postgres image.