### PR TITLE
Ensure table creation is multi-instance safe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 #
-# Go Environment Settings
+# Go Settings
 #
 ARG GO_NO_PROXY=github.com/SUSE
+ARG GOLANG_BASE=registry.suse.com/bci/golang
+ARG GOLANG_VERSION=1.23-openssl
 
 #
 # PostgreSQL Settings
@@ -49,7 +51,7 @@ RUN chmod +x /telemetry/*.bash
 #
 # Build the code in BCI golang based image
 #
-FROM registry.suse.com/bci/golang:1.23-openssl AS builder-base
+FROM ${GOLANG_BASE}:${GOLANG_VERSION} AS builder-base
 
 # these args are used in this stage
 ARG telemetryCacheDir

--- a/app/handler_report.go
+++ b/app/handler_report.go
@@ -137,7 +137,7 @@ func (a *App) ReportTelemetry(ar *AppRequest) {
 		// a summary error and fail request with combined error
 		ar.ErrorResponse(
 			http.StatusBadRequest,
-			fmt.Errorf("Staged report processing failed:\n%w", err).Error(),
+			fmt.Errorf("staged report processing failed:\n%w", err).Error(),
 		)
 		return
 	}

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -16,8 +16,6 @@ services:
     depends_on:
       db:
         condition: service_healthy
-      init-db:
-        condition: service_completed_successfully
       pre-deploy-checks:
         condition: service_completed_successfully
     healthcheck:
@@ -41,10 +39,10 @@ services:
     ports:
       - "9998:9998"
     depends_on:
-      tsg:
-        condition: service_healthy
       db:
         condition: service_healthy
+      pre-deploy-checks:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD-SHELL", "curl --fail --insecure http://tsa:9998/healthz || exit 1"]
       interval: 5s


### PR DESCRIPTION
Use transactions and advisory locking to avoid errors when there are racing instances attempting to create the database tables.

Update docker/compose.yaml dependencies to reflect that it is safe to start the telemetry server and admin instances simultaneously.

Parameterise Go base image and version tag in the Dockerfile.

Minor typo fixes.

Remove redundant code.