### PR TITLE
Ensure we build and publish correct target images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,6 +60,15 @@ jobs:
       - name: Build and Push
         uses: docker/build-push-action@v6
         with:
+          # ensure we pull the latest base images
+          pull: true
+          # push target image
           push: true
+          # choose the target build stage we want to build
+          target: telemetry-${{ matrix.suffix }}
+          # apply these tags and labels to the built target image
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # use GitHub Action Caches to speed up the build process
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Makefile.compose
+++ b/Makefile.compose
@@ -7,10 +7,11 @@ PG_DOCKER_VOLUME = docker_pgdata
 # Start the telemetry-server using docker (or podman) compose
 compose-build: vet
 	cd docker && $(CNTR_MGR) compose build \
-		--build-arg logLevel=$(LOG_LEVEL) \
-		--build-arg telemetryCfgDir=/etc/susetelemetry \
-		--build-arg telemetryRepoBranch=$(TELEMETRY_REPO_BRANCH) \
-		--build-arg telemetryImageVariant=$(if $(filter-out main,$(TELEMETRY_REPO_BRANCH)),specified,upstream)
+	  --pull \
+	  --build-arg logLevel=$(LOG_LEVEL) \
+	  --build-arg telemetryCfgDir=/etc/susetelemetry \
+	  --build-arg telemetryRepoBranch=$(TELEMETRY_REPO_BRANCH) \
+	  --build-arg telemetryImageVariant=$(if $(filter-out main,$(TELEMETRY_REPO_BRANCH)),specified,upstream)
 
 compose-start compose-up: compose-build
 	cd docker && $(CNTR_MGR) compose --parallel 4 up --wait -d

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -11,11 +11,15 @@ TELEMETRY_CONTAINERS = \
 # Start the telemetry containers using docker
 docker-build: vet
 	for cntr in $(TELEMETRY_CONTAINERS); do \
-		$(CNTR_MGR) build -t $${cntr} --target $${cntr} . \
+		$(CNTR_MGR) build \
+		  --pull \
+		  --tag $${cntr} \
+		  --target $${cntr} \
+		  . \
 		  --build-arg logLevel=$(LOG_LEVEL) \
 		  --build-arg telemetryCfgDir=/etc/susetelemetry \
-			--build-arg telemetryRepoBranch=$(TELEMETRY_REPO_BRANCH) \
-			--build-arg telemetryImageVariant=$(if $(filter-out main,$(TELEMETRY_REPO_BRANCH)),specified,upstream); \
+		  --build-arg telemetryRepoBranch=$(TELEMETRY_REPO_BRANCH) \
+		  --build-arg telemetryImageVariant=$(if $(filter-out main,$(TELEMETRY_REPO_BRANCH)),specified,upstream); \
 	done
 
 docker-start docker-run: docker-build


### PR DESCRIPTION
When building images using our Dockerfile we need to ensure that we specify the build stage target for the image that we want to build using the target attribute.

Additionally enable GitHub Actions caching for the image build action to speed up subsequent build runs.

Also enable pulling of the latest base images when building images, either locally (via docker-build or compose-build make targets) and in the GitHub Actions workflow.