### PR TITLE
Implement simplified /report request handling

### DIFF
--- a/app/handler_register.go
+++ b/app/handler_register.go
@@ -74,6 +74,7 @@ func (a *App) RegisterClient(ar *AppRequest) {
 	client.AuthToken, err = a.AuthManager.CreateToken()
 	if err != nil {
 		ar.ErrorResponse(http.StatusInternalServerError, "failed to create authtoken for client")
+		return
 	}
 
 	client.RegistrationDate = types.Now().String()

--- a/app/handler_report.go
+++ b/app/handler_report.go
@@ -8,9 +8,20 @@ import (
 	"net/http"
 	"strconv"
 
+	telemetrylib "github.com/SUSE/telemetry/pkg/lib"
 	"github.com/SUSE/telemetry/pkg/restapi"
 	"github.com/SUSE/telemetry/pkg/types"
 )
+
+var stageTelemetryReports bool = false
+
+func EnableTelemetryReportStaging() {
+	stageTelemetryReports = true
+}
+
+func DisableTelemetryReportStaging() {
+	stageTelemetryReports = false
+}
 
 func (a *App) ReportTelemetry(ar *AppRequest) {
 	ar.Log.Info("Processing")
@@ -122,30 +133,115 @@ func (a *App) ReportTelemetry(ar *AppRequest) {
 	}
 	ar.Log.Debug("Checksums verified")
 
-	// save the report into the operational db
-	err = a.StageTelemetryReport(reqBody, &trReq.TelemetryReport.Header)
-	if err != nil {
-		ar.ErrorResponse(http.StatusBadRequest, err.Error())
-		return
-	}
-
-	// process pending reports
-	err = a.ProcessStagedReports()
-	if err != nil {
-		// err is a joined slice of multiple errors for which err.Error()
-		// will return a multiline string, one error per line, so prepend
-		// a summary error and fail request with combined error
-		ar.ErrorResponse(
-			http.StatusBadRequest,
-			fmt.Errorf("staged report processing failed:\n%w", err).Error(),
+	// telemetry reports can be either handled inline or staged
+	// for later processing
+	var stagingId int64 = 0
+	if !stageTelemetryReports {
+		err = a.ProcessTelemetryReport(&trReq.TelemetryReport)
+		if err != nil {
+			ar.ErrorResponse(
+				http.StatusBadRequest,
+				fmt.Errorf("report processing failed: %w", err).Error(),
+			)
+			return
+		}
+	} else {
+		// save the report into the operational db, obtaining the staging
+		// db's entry id if successful
+		stagingId, err = a.StageTelemetryReport(
+			reqBody,
+			&trReq.TelemetryReport.Header,
 		)
-		return
+		if err != nil {
+			ar.ErrorResponse(http.StatusBadRequest, err.Error())
+			return
+		}
+
+		// process pending reports
+		err = a.ProcessStagedReports()
+		if err != nil {
+			// err is a joined slice of multiple errors for which err.Error()
+			// will return a multiline string, one error per line, so prepend
+			// a summary error and fail request with combined error
+			ar.ErrorResponse(
+				http.StatusBadRequest,
+				fmt.Errorf("staged report processing failed:\n%w", err).Error(),
+			)
+			return
+		}
 	}
 
-	// initialise a telemetry report response
-	trResp := restapi.NewTelemetryReportResponse(0, types.Now())
+	// initialise a telemetry report response, stagingId will be 0 if we
+	// processed the report inline, otherwise it will be the id of the
+	// entry in the staging table, which will be processed at a later time.
+	trResp := restapi.NewTelemetryReportResponse(stagingId, types.Now())
 	ar.Log.Debug("Response", slog.Any("trResp", trResp))
 
 	// respond success with the telemetry report response
 	ar.JsonResponse(http.StatusOK, trResp)
+}
+
+func (a *App) ProcessTelemetryReport(report *telemetrylib.TelemetryReport) error {
+	numBundles := len(report.TelemetryBundles)
+	var totalItems int
+
+	slog.Info(
+		"Processing telemetry report",
+		slog.String("reportId", report.Header.ReportId),
+		slog.String("reportClientId", report.Header.ReportClientId),
+		slog.Int("numBundles", numBundles),
+	)
+
+	// process available bundles, extracting the data items and
+	// storing them in the telemetry DB
+	for _, bundle := range report.TelemetryBundles {
+		numItems := len(bundle.TelemetryDataItems)
+
+		slog.Debug(
+			"Processing telemetry bundle",
+			slog.String("bundleId", bundle.Header.BundleId),
+			slog.String("bundleClientId", bundle.Header.BundleClientId),
+			slog.Int("numItems", numItems),
+		)
+
+		// for each data item in the bundle, process it
+		for _, item := range bundle.TelemetryDataItems {
+			slog.Debug(
+				"Processing telemetry data item",
+				slog.String("telemetryId", item.Header.TelemetryId),
+				slog.String("telemetryType", item.Header.TelemetryType),
+			)
+
+			if err := a.StoreTelemetry(&item, &bundle.Header); err != nil {
+				slog.Error(
+					"Failed to store telemetry data item",
+					slog.String("telemetryId", item.Header.TelemetryId),
+					slog.String("telemetryType", item.Header.TelemetryType),
+					slog.String("bundleId", bundle.Header.BundleId),
+					slog.String("bundleClientId", bundle.Header.BundleClientId),
+					slog.String("error", err.Error()),
+				)
+				return fmt.Errorf(
+					"failed to store telemetry item %q from bundle %q in report %q: %w",
+					item.Header.TelemetryId,
+					bundle.Header.BundleId,
+					report.Header.ReportId,
+					err,
+				)
+			}
+		}
+
+		// increment the number of items processed
+		totalItems += numItems
+	}
+
+	slog.Info(
+		"Successfully processed telemetry report",
+		slog.String("reportId", report.Header.ReportId),
+		slog.String("reportClientId", report.Header.ReportClientId),
+		slog.Int("numBundles", numBundles),
+		slog.Int("totalItems", totalItems),
+	)
+
+	return nil
 }


### PR DESCRIPTION
Switch the /report request handling to process the provided telemetry report inline, rather than staging it and then running the background processing loop. This should reduce the operational DB's load for now as we don't need to create a transaction to add the report.

Retain the original code flow for now in a disabled by default state, with tweaks to return the id of the entry added to the staging table that will be used as the processing id in the payload of the /report response; a value of 0 indicates inline processing, and a non-zero value indicates that background processing was used.

Added a missing return in the error handling of the /register request in the case where there is a failure generating a new AuthToken.