### PR TITLE
/authenticate backwards compatibile regHash check

### DIFF
--- a/app/handler_authenticate.go
+++ b/app/handler_authenticate.go
@@ -54,11 +54,14 @@ func (a *App) AuthenticateClient(ar *AppRequest) {
 
 	// confirm that the provided registration hash matches the registered one
 	regHash := client.GetClientRegistration().Hash(caReq.RegHash.Method)
-	if !regHash.Match(&caReq.RegHash) {
+	// TODO: remove HashJSON() workaround when no longer needed
+	regHashJSON := client.GetClientRegistration().HashJSON(caReq.RegHash.Method)
+	if !regHash.Match(&caReq.RegHash) && !regHashJSON.Match(&caReq.RegHash) {
 		ar.Log.Error(
 			"Registration hash mismatch",
 			slog.String("Req Hash", caReq.RegHash.String()),
 			slog.String("DB Hash", regHash.String()),
+			slog.String("DB HashJSON", regHashJSON.String()),
 		)
 		// client needs to re-register
 		ar.SetWwwAuthRegister()


### PR DESCRIPTION
This should allow older clients to talk to a server that has been updated with the latest SUSE/Telemetry client code.

TelemetryRepoBranch: change_regHash_input_value