### PR TITLE
[feat] Throttle Middleware

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -16,6 +16,7 @@ import (
 	"github.com/SUSE/telemetry-server/app/database"
 	"github.com/SUSE/telemetry-server/app/database/operationaldb"
 	"github.com/SUSE/telemetry-server/app/database/telemetrydb"
+	"github.com/SUSE/telemetry-server/app/middleware"
 	"github.com/SUSE/telemetry/pkg/logging"
 	_ "github.com/mattn/go-sqlite3"
 )
@@ -41,6 +42,7 @@ type App struct {
 	Handler       http.Handler
 	LogManager    *logging.LogManager
 	AuthManager   *AuthManager
+	Throttler     *middleware.Throttler
 
 	// private
 	server    *http.Server
@@ -58,6 +60,7 @@ func NewApp(name string, cfg *config.Config, handler http.Handler, debugMode boo
 	a.Handler = handler
 	a.debugMode = debugMode
 	a.signals = make(chan os.Signal, 1)
+	a.Throttler = middleware.NewThrottler(a.Config.API.MaxParallelReq)
 
 	// setup logging first so remaining setup logs with config settings
 	if err := a.SetupLogging(); err != nil {

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -15,8 +15,9 @@ const DEFAULT_CONFIG string = "/etc/susetelemetry/server.cfg"
 
 // API server config
 type APIConfig struct {
-	Host string `yaml:"host"`
-	Port int    `yaml:"port"`
+	Host           string `yaml:"host"`
+	Port           int    `yaml:"port"`
+	MaxParallelReq int    `yaml:"max_parallel_requests"`
 }
 
 type PQLConfig struct {

--- a/app/middleware/throttle.go
+++ b/app/middleware/throttle.go
@@ -1,0 +1,32 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+)
+
+type Throttler struct {
+	sem chan struct{}
+}
+
+func NewThrottler(maxConcurrent int) *Throttler {
+	return &Throttler{
+		sem: make(chan struct{}, maxConcurrent),
+	}
+}
+
+func (t *Throttler) Wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+
+		select {
+		case t.sem <- struct{}{}:
+			defer func() { <-t.sem }()
+			next.ServeHTTP(w, r.WithContext(ctx))
+
+		case <-ctx.Done():
+			http.Error(w, "Request timeout waiting for throttle slot", http.StatusTooManyRequests)
+		}
+	})
+}

--- a/app/middleware/throttle_test.go
+++ b/app/middleware/throttle_test.go
@@ -1,0 +1,64 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/SUSE/telemetry-server/app/middleware"
+)
+
+// TestThrottler_LimitsConcurrentRequests checks that the Throttler enforces max concurrency
+func TestThrottler_LimitsConcurrentRequests(t *testing.T) {
+	// Only allow 2 concurrent requests
+	throttler := middleware.NewThrottler(2)
+
+	var (
+		active     int
+		maxActive  int
+		mu         sync.Mutex
+		wg         sync.WaitGroup
+		totalCalls = 5
+	)
+
+	// Fake handler simulating 100ms processing
+	handler := throttler.Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		active++
+		if active > maxActive {
+			maxActive = active
+		}
+		mu.Unlock()
+
+		time.Sleep(100 * time.Millisecond) // simulate work
+
+		mu.Lock()
+		active--
+		mu.Unlock()
+
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Start 5 concurrent requests
+	for i := 0; i < totalCalls; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest("GET", "/", nil)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Errorf("unexpected status code: got %d, want %d", rr.Code, http.StatusOK)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	if maxActive > 2 {
+		t.Errorf("too many concurrent requests: maxActive = %d, want <= 2", maxActive)
+	}
+}

--- a/server/telemetry-admin/app_test.go
+++ b/server/telemetry-admin/app_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/SUSE/telemetry-server/app"
 	"github.com/SUSE/telemetry-server/app/config"
+	"github.com/SUSE/telemetry-server/app/middleware"
 	"github.com/SUSE/telemetry/pkg/types"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
@@ -27,6 +28,7 @@ type AppTestSuite struct {
 	clientReg     types.ClientRegistration
 	clientRegHash types.ClientRegistrationHash
 	regId         int64
+	Throttler     *middleware.Throttler
 }
 
 // run before each test
@@ -44,6 +46,7 @@ func (s *AppTestSuite) SetupTest() {
 api:
   host: localhost
   port: 9998
+  max_parallel_requests: 80
 dbs:
   telemetry:
     driver: sqlite3

--- a/server/telemetry-server/app_test.go
+++ b/server/telemetry-server/app_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/SUSE/telemetry-server/app"
 	"github.com/SUSE/telemetry-server/app/config"
+	"github.com/SUSE/telemetry-server/app/middleware"
 	"github.com/SUSE/telemetry/pkg/restapi"
 	"github.com/SUSE/telemetry/pkg/types"
 	"github.com/google/uuid"
@@ -39,6 +40,7 @@ type AppTestSuite struct {
 	clientReg     types.ClientRegistration
 	clientRegHash types.ClientRegistrationHash
 	regId         int64
+	throttler     *middleware.Throttler
 }
 
 // run before each test
@@ -56,6 +58,7 @@ func (s *AppTestSuite) SetupTest() {
 api:
   host: localhost
   port: 9999
+  max_parallel_requests: 80
 dbs:
   telemetry:
     driver: sqlite3

--- a/server/telemetry-server/main.go
+++ b/server/telemetry-server/main.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/SUSE/telemetry-server/app"
 	"github.com/SUSE/telemetry-server/app/config"
-	"github.com/SUSE/telemetry-server/app/middleware"
 	"github.com/SUSE/telemetry/pkg/logging"
 	"github.com/gorilla/mux"
 )
@@ -94,14 +93,14 @@ func parseCommandLineFlags() {
 	flag.Parse()
 }
 
-func SetupRouterWrapper(router *mux.Router, app *app.App, t *middleware.Throttler) {
+func SetupRouterWrapper(router *mux.Router, app *app.App) {
 	wrapper := newRouterWrapper(router, app)
 
 	// Throttled routes
-	router.Handle("/telemetry/report", t.Wrap(http.HandlerFunc(wrapper.reportTelemetry))).Methods("POST")
+	router.Handle("/telemetry/report", app.Throttler.Wrap(http.HandlerFunc(wrapper.reportTelemetry))).Methods("POST")
+	router.Handle("/telemetry/authenticate", app.Throttler.Wrap(http.HandlerFunc(wrapper.authenticateClient))).Methods("POST")
+	router.Handle("/telemetry/register", app.Throttler.Wrap(http.HandlerFunc(wrapper.registerClient))).Methods("POST")
 
-	router.HandleFunc("/telemetry/authenticate", wrapper.authenticateClient).Methods("POST")
-	router.HandleFunc("/telemetry/register", wrapper.registerClient).Methods("POST")
 	router.HandleFunc("/healthz", wrapper.healthCheck).Methods("GET", "HEAD")
 	router.HandleFunc("/live", wrapper.liveCheck).Methods("GET", "HEAD")
 	router.HandleFunc("/version", wrapper.getVersion).Methods("GET", "HEAD")
@@ -111,9 +110,8 @@ func InitializeApp(cfg *config.Config, debug bool) (a *app.App, router *mux.Rout
 	router = mux.NewRouter()
 
 	a = app.NewApp("Server", cfg, router, debug)
-	t := middleware.NewThrottler(80)
 
-	SetupRouterWrapper(router, a, t)
+	SetupRouterWrapper(router, a)
 
 	if err := a.Initialize(); err != nil {
 		panic(err)

--- a/testdata/config/composeAdmin.yaml
+++ b/testdata/config/composeAdmin.yaml
@@ -1,7 +1,7 @@
 api:
   host: tsa
   port: 9998
-  max_parallel_requets: 80
+  max_parallel_requests: 80
 dbs:
   telemetry:
     driver: postgres

--- a/testdata/config/composeAdmin.yaml
+++ b/testdata/config/composeAdmin.yaml
@@ -1,6 +1,7 @@
 api:
   host: tsa
   port: 9998
+  max_parallel_requets: 80
 dbs:
   telemetry:
     driver: postgres

--- a/testdata/config/composeServer.yaml
+++ b/testdata/config/composeServer.yaml
@@ -1,7 +1,7 @@
 api:
   host: tsg
   port: 9999
-  max_parallel_requets: 80
+  max_parallel_requests: 80
 dbs:
   telemetry:
     driver: postgres

--- a/testdata/config/composeServer.yaml
+++ b/testdata/config/composeServer.yaml
@@ -1,6 +1,7 @@
 api:
   host: tsg
   port: 9999
+  max_parallel_requets: 80
 dbs:
   telemetry:
     driver: postgres

--- a/testdata/config/dockerAdmin.yaml
+++ b/testdata/config/dockerAdmin.yaml
@@ -1,6 +1,7 @@
 api:
   host: 0.0.0.0
   port: 9998
+  max_parallel_requets: 80
 dbs:
   telemetry:
     driver: sqlite3

--- a/testdata/config/dockerAdmin.yaml
+++ b/testdata/config/dockerAdmin.yaml
@@ -1,7 +1,7 @@
 api:
   host: 0.0.0.0
   port: 9998
-  max_parallel_requets: 80
+  max_parallel_requests: 80
 dbs:
   telemetry:
     driver: sqlite3

--- a/testdata/config/dockerServer.yaml
+++ b/testdata/config/dockerServer.yaml
@@ -1,6 +1,7 @@
 api:
   host: 0.0.0.0
   port: 9999
+  max_parallel_requets: 80
 dbs:
   telemetry:
     driver: sqlite3

--- a/testdata/config/dockerServer.yaml
+++ b/testdata/config/dockerServer.yaml
@@ -1,7 +1,7 @@
 api:
   host: 0.0.0.0
   port: 9999
-  max_parallel_requets: 80
+  max_parallel_requests: 80
 dbs:
   telemetry:
     driver: sqlite3

--- a/testdata/config/localAdmin.yaml
+++ b/testdata/config/localAdmin.yaml
@@ -1,6 +1,7 @@
 api:
   host: localhost
   port: 9999
+  max_parallel_requets: 80
 dbs:
   telemetry:
     driver: sqlite3

--- a/testdata/config/localAdmin.yaml
+++ b/testdata/config/localAdmin.yaml
@@ -1,7 +1,7 @@
 api:
   host: localhost
   port: 9999
-  max_parallel_requets: 80
+  max_parallel_requests: 80
 dbs:
   telemetry:
     driver: sqlite3

--- a/testdata/config/localServer.yaml
+++ b/testdata/config/localServer.yaml
@@ -1,6 +1,7 @@
 api:
   host: localhost
   port: 9999
+  max_parallel_requets: 80
 dbs:
   telemetry:
     driver: sqlite3

--- a/testdata/config/localServer.yaml
+++ b/testdata/config/localServer.yaml
@@ -1,7 +1,7 @@
 api:
   host: localhost
   port: 9999
-  max_parallel_requets: 80
+  max_parallel_requests: 80
 dbs:
   telemetry:
     driver: sqlite3


### PR DESCRIPTION
# feat - Request Throttling Middleware

## Summary

Introduces a middleware to control the number of concurrent in-flight requests handled by the telemetry server.

## Implementation

- Added a `Throttler` middleware using a buffered `chan struct{}` as a semaphore.
- Hard limit of 80 concurrent requests.
- Excess requests wait for a slot until the request context is canceled (e.g., client timeout).
- Requests that time out return `429 Too Many Requests`.
- Applied throttling only to selected routes that query the database.
- Endpoints (health, liveness, version, and authentication) are left unthrottled.

## Motivation

Stress testing showed that heavy concurrent load could block health check and liveness probes, causing pod restarts. This change mitigates that by limiting concurrent access to resource-intensive routes.
