### PR TITLE
Transactional DB operations in request handling

### DIFF
--- a/app/database/clients.go
+++ b/app/database/clients.go
@@ -80,9 +80,9 @@ func (c *ClientsRow) String() string {
 	return string(bytes)
 }
 
-func (c *ClientsRow) SetupDB(adb *AppDb) (err error) {
+func (c *ClientsRow) SetupDB(adb *AppDb, tx *sql.Tx) {
 	c.SetTableSpec(GetClientsTableSpec())
-	return c.TableRowCommon.SetupDB(adb)
+	c.TableRowCommon.SetupDB(adb, tx)
 }
 
 func (c *ClientsRow) Exists() bool {
@@ -110,7 +110,7 @@ func (c *ClientsRow) Exists() bool {
 		panic(err)
 	}
 
-	row := c.DB().QueryRow(stmt, c.Id)
+	row := c.Tx().QueryRow(stmt, c.Id)
 	// if the entry was found, all fields not used to find the entry will have
 	// been updated to match what is in the DB
 	if err := row.Scan(
@@ -158,7 +158,7 @@ func (c *ClientsRow) RegistrationExists() bool {
 		panic(err)
 	}
 
-	row := c.DB().QueryRow(
+	row := c.Tx().QueryRow(
 		stmt,
 		c.ClientId,
 		c.SystemUUID,
@@ -211,7 +211,7 @@ func (c *ClientsRow) ClientIdExists() bool {
 		panic(err)
 	}
 
-	row := c.DB().QueryRow(
+	row := c.Tx().QueryRow(
 		stmt,
 		c.ClientId,
 	)
@@ -258,7 +258,7 @@ func (c *ClientsRow) Insert() (err error) {
 		)
 		return
 	}
-	row := c.DB().QueryRow(
+	row := c.Tx().QueryRow(
 		stmt,
 		c.ClientId,
 		c.SystemUUID,
@@ -303,7 +303,7 @@ func (c *ClientsRow) Update() (err error) {
 		)
 		return
 	}
-	_, err = c.DB().Exec(
+	_, err = c.Tx().Exec(
 		stmt,
 		c.ClientId,
 		c.SystemUUID,
@@ -338,7 +338,7 @@ func (c *ClientsRow) Delete() (err error) {
 		return
 	}
 
-	_, err = c.DB().Exec(
+	_, err = c.Tx().Exec(
 		stmt,
 		c.Id,
 	)

--- a/app/database/customers.go
+++ b/app/database/customers.go
@@ -42,9 +42,9 @@ func (r *CustomersRow) Init(customerId string) {
 	r.CustomerId = customerId
 }
 
-func (r *CustomersRow) SetupDB(adb *AppDb) (err error) {
+func (r *CustomersRow) SetupDB(adb *AppDb, tx *sql.Tx) {
 	r.SetTableSpec(GetCustomersTableSpec())
-	return r.TableRowCommon.SetupDB(adb)
+	r.TableRowCommon.SetupDB(adb, tx)
 }
 
 func (r *CustomersRow) TableName() string {
@@ -83,7 +83,7 @@ func (r *CustomersRow) Exists() bool {
 		panic(err)
 	}
 
-	row := r.DB().QueryRow(stmt, r.CustomerId, r.Deleted)
+	row := r.Tx().QueryRow(stmt, r.CustomerId, r.Deleted)
 	// if the entry was found, all fields not used to find the entry will have
 	// been updated to match what is in the DB
 	if err := row.Scan(
@@ -126,7 +126,7 @@ func (r *CustomersRow) IdExists() bool {
 		panic(err)
 	}
 
-	row := r.DB().QueryRow(stmt, r.Id)
+	row := r.Tx().QueryRow(stmt, r.Id)
 	// if the entry was found, all fields not used to find the entry will have
 	// been updated to match what is in the DB
 	if err := row.Scan(
@@ -164,7 +164,7 @@ func (r *CustomersRow) Insert() (err error) {
 		)
 		return
 	}
-	row := r.DB().QueryRow(
+	row := r.Tx().QueryRow(
 		stmt,
 		r.CustomerId,
 		r.Deleted,
@@ -205,7 +205,7 @@ func (r *CustomersRow) Update() (err error) {
 		)
 		return
 	}
-	_, err = r.DB().Exec(
+	_, err = r.Tx().Exec(
 		stmt,
 		r.CustomerId,
 		r.Deleted,
@@ -239,7 +239,7 @@ func (r *CustomersRow) Delete() (err error) {
 		return
 	}
 
-	_, err = r.DB().Exec(
+	_, err = r.Tx().Exec(
 		stmt,
 		r.Id,
 	)

--- a/app/database/dbconnection.go
+++ b/app/database/dbconnection.go
@@ -328,7 +328,7 @@ func (d *DbConnection) CreateTableFromSpec(table *TableSpec) (err error) {
 		)
 	}
 
-	// defer releaseing the advisory lock
+	// defer releasing the advisory lock
 	defer func() {
 		d.ReleaseAdvisdoryLock(CREATE_TABLE_ADVISORY, tx, false)
 	}()

--- a/app/database/tagsets.go
+++ b/app/database/tagsets.go
@@ -34,9 +34,9 @@ func (t *TagSetRow) String() string {
 	return string(bytes)
 }
 
-func (t *TagSetRow) SetupDB(adb *AppDb) error {
+func (t *TagSetRow) SetupDB(adb *AppDb, tx *sql.Tx) {
 	t.SetTableSpec(GetTagSetsTableSpec())
-	return t.TableRowCommon.SetupDB(adb)
+	t.TableRowCommon.SetupDB(adb, tx)
 }
 
 func (t *TagSetRow) RowId() int64 {
@@ -62,7 +62,7 @@ func (t *TagSetRow) Exists() bool {
 		panic(err)
 	}
 
-	row := t.DB().QueryRow(stmt, t.TagSet)
+	row := t.Tx().QueryRow(stmt, t.TagSet)
 	if err := row.Scan(&t.Id); err != nil {
 		if err != sql.ErrNoRows {
 			slog.Error("tagSet existence check failed", slog.String("tagSet", t.TagSet), slog.String("error", err.Error()))
@@ -87,7 +87,7 @@ func (t *TagSetRow) Insert() (err error) {
 		)
 		return
 	}
-	row := t.DB().QueryRow(
+	row := t.Tx().QueryRow(
 		stmt,
 		t.TagSet,
 	)
@@ -123,7 +123,7 @@ func (t *TagSetRow) Update() (err error) {
 		return
 	}
 
-	_, err = t.DB().Exec(
+	_, err = t.Tx().Exec(
 		stmt,
 		t.TagSet,
 		t.Id,
@@ -155,7 +155,7 @@ func (t *TagSetRow) Delete() (err error) {
 		return
 	}
 
-	_, err = t.DB().Exec(
+	_, err = t.Tx().Exec(
 		stmt,
 		t.Id,
 	)

--- a/app/database/telemetry.go
+++ b/app/database/telemetry.go
@@ -75,10 +75,10 @@ func (t *TelemetryDataRow) Init(
 	return
 }
 
-func (t *TelemetryDataRow) SetupDB(adb *AppDb) (err error) {
+func (t *TelemetryDataRow) SetupDB(adb *AppDb, tx *sql.Tx) {
 	// save DB reference
 	t.SetTableSpec(GetTelemetryTableSpec())
-	return t.TableRowCommon.SetupDB(adb)
+	t.TableRowCommon.SetupDB(adb, tx)
 }
 
 func (t *TelemetryDataRow) TableName() string {
@@ -122,7 +122,7 @@ func (t *TelemetryDataRow) Exists() bool {
 		panic(err)
 	}
 
-	row := t.DB().QueryRow(
+	row := t.Tx().QueryRow(
 		stmt,
 		t.ClientId,
 		t.TelemetryId,
@@ -174,7 +174,7 @@ func (t *TelemetryDataRow) Insert() (err error) {
 		return
 	}
 
-	row := t.DB().QueryRow(
+	row := t.Tx().QueryRow(
 		stmt,
 		t.ClientId,
 		t.CustomerRefId,
@@ -224,7 +224,7 @@ func (t *TelemetryDataRow) Update() (err error) {
 		return
 	}
 
-	_, err = t.DB().Exec(
+	_, err = t.Tx().Exec(
 		stmt,
 		t.ClientId,
 		t.CustomerRefId,
@@ -261,7 +261,7 @@ func (t *TelemetryDataRow) Delete() (err error) {
 		return
 	}
 
-	_, err = t.DB().Exec(
+	_, err = t.Tx().Exec(
 		stmt,
 		t.Id,
 	)

--- a/app/staging.go
+++ b/app/staging.go
@@ -11,16 +11,31 @@ import (
 )
 
 func (a *App) StageTelemetryReport(reqBody []byte, rHeader *telemetrylib.TelemetryReportHeader) (stagingId int64, err error) {
-	// Stores the report body in the operational database's reports table
-
-	// create a ReportStagingTableRow struct
-
-	reportStagingRow := new(database.ReportStagingTableRow)
-	if err = reportStagingRow.SetupDB(a.OperationalDB); err != nil {
-		slog.Error("ReportStagingTableRow.SetupDB failed", slog.String("error", err.Error()))
+	//
+	// create an operationalDb transaction
+	//
+	odbTx, err := a.OperationalDB.StartTx()
+	if err != nil {
+		slog.Error(
+			"Failed to start a tranaction to stage a telemetry report",
+			slog.String("reportId", rHeader.ReportId),
+			slog.String("error", err.Error()),
+		)
 		return
 	}
 
+	// defer a rollback of the operationalDb transaction
+	defer func() {
+		a.OperationalDB.RollbackTx(odbTx, "AuthenticateClient")
+	}()
+
+	//
+	// Store the report body in the operational database's reports table
+	//
+
+	// create a ReportStagingTableRow struct
+	reportStagingRow := new(database.ReportStagingTableRow)
+	reportStagingRow.SetupDB(a.OperationalDB, odbTx)
 	reportStagingRow.Init(
 		rHeader.ReportClientId,
 		rHeader.ReportId,
@@ -29,7 +44,17 @@ func (a *App) StageTelemetryReport(reqBody []byte, rHeader *telemetrylib.Telemet
 
 	stagingId, err = reportStagingRow.Insert()
 	if err != nil {
-		slog.Error("staged report insert failed", slog.String("report", reportStagingRow.ReportIdentifer()), slog.String("error", err.Error()))
+		slog.Error(
+			"staged report insert failed",
+			slog.String("report", reportStagingRow.ReportIdentifer()),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+
+	// commit the transaction
+	if err = a.OperationalDB.CommitTx(odbTx); err != nil {
+		return 0, err
 	}
 
 	return
@@ -37,9 +62,27 @@ func (a *App) StageTelemetryReport(reqBody []byte, rHeader *telemetrylib.Telemet
 
 func (a *App) ProcessStagedReports() error {
 	var errs []error
-
 	reportRow := new(database.ReportStagingTableRow)
-	reportRow.SetupDB(a.OperationalDB)
+
+	//
+	// create an operationalDb transaction
+	//
+	odbTx, err := a.OperationalDB.StartTx()
+	if err != nil {
+		slog.Error(
+			"Failed to start a tranaction to process staged telemetry reports",
+			slog.String("error", err.Error()),
+		)
+		errs = append(errs, fmt.Errorf("staged report transaction start failed: %w", err))
+		goto join_errors
+	}
+
+	// defer a rollback of the operationalDb transaction
+	defer func() {
+		a.OperationalDB.RollbackTx(odbTx, "AuthenticateClient")
+	}()
+
+	reportRow.SetupDB(a.OperationalDB, odbTx)
 
 	for reportRow.FirstUnallocated() {
 		err := a.ProcessStagedReport(reportRow)
@@ -65,6 +108,16 @@ func (a *App) ProcessStagedReports() error {
 		}
 	}
 
+	// commit the transaction
+	if err = a.OperationalDB.CommitTx(odbTx); err != nil {
+		slog.Error(
+			"Failed to commit a tranaction after processing staged telemetry reports",
+			slog.String("error", err.Error()),
+		)
+		errs = append(errs, fmt.Errorf("staged report transaction commit failed: %w", err))
+	}
+
+join_errors:
 	return errors.Join(errs...)
 }
 


### PR DESCRIPTION
Rework the DB interaction patterns of our request handlers to create transactions for any DB they are interacting with during the initial request handling setup, with appropriate rollback on failure. These transactions are then used for all operations that access the DBs during request processing, with appropriate TX commit processing as part of the succesful completion of the request handlers.

Performance impact of explicitly creating transactions is relatively small as Postgres implicitly creates transactions for all requests. Under simulated heavy loads the performance of the service seemed a little less variable using this approach than the previous approach.